### PR TITLE
Coverage Report workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,35 @@
+name: 'Coverage Report'
+
+on:
+  release:
+    types: [ published ]
+
+
+jobs:
+  coverage:
+    if: github.repository == 'USEPA/the-manifest-game'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Report
+        id: coverage
+        run: npm run coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          overwrite: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [ 'main' ]
   push:
+    branches-ignore: [ 'main' ]
   workflow_call:
 
 jobs:
@@ -23,7 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
 
       - name: 'Install Dependencies'
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Tests](https://github.com/USEPA/the-manifest-game/actions/workflows/test.yaml/badge.svg)](https://github.com/USEPA/the-manifest-game/actions/workflows/test.yaml)
 [![Build](https://github.com/USEPA/the-manifest-game/actions/workflows/build.yaml/badge.svg)](https://github.com/USEPA/the-manifest-game/actions/workflows/build.yaml/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 An interactive decision tree to assist e-Manifest users determine the necessary course of action.
 


### PR DESCRIPTION
## Description

Add a new Coverage Report workflow, that uses vitest to generate a test coverage report and upload as a GitHub artifact.

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
