### PR TITLE
Config error path

### DIFF
--- a/public/default.json
+++ b/public/default.json
@@ -1,273 +1,275 @@
-[
-  {
-    "id": "0",
-    "type": "default",
-    "data": {
-      "label": "Create an electronic manifest (click me)",
-      "children": [
-        "1",
-        "2"
-      ]
+{
+  "nodes": [
+    {
+      "id": "0",
+      "type": "default",
+      "data": {
+        "label": "Create an electronic manifest (click me)",
+        "children": [
+          "1",
+          "2"
+        ]
+      }
+    },
+    {
+      "id": "1",
+      "type": "default",
+      "data": {
+        "label": "I am a Generator or Transporter",
+        "children": [
+          "15"
+        ]
+      }
+    },
+    {
+      "id": "2",
+      "type": "default",
+      "data": {
+        "label": "I am a TSDF",
+        "children": [
+          "3"
+        ]
+      }
+    },
+    {
+      "id": "3",
+      "type": "BoolNode",
+      "data": {
+        "label": "Generator can sign electronically?",
+        "yesId": "4",
+        "noId": "5",
+        "children": [
+          "4",
+          "5"
+        ]
+      }
+    },
+    {
+      "id": "4",
+      "type": "default",
+      "data": {
+        "label": "Create a Fully Electronic Manifest and set to Scheduled",
+        "children": [
+          "6"
+        ]
+      }
+    },
+    {
+      "id": "5",
+      "type": "default",
+      "data": {
+        "label": "Create a Hybrid Manifest and set to Scheduled",
+        "children": [
+          "7"
+        ]
+      }
+    },
+    {
+      "id": "7",
+      "type": "default",
+      "data": {
+        "label": "Transporter prints 2 paper copies",
+        "children": [
+          "8"
+        ]
+      }
+    },
+    {
+      "id": "8",
+      "type": "default",
+      "data": {
+        "label": "Generator signs on paper and keeps a copy",
+        "children": [
+          "9"
+        ]
+      }
+    },
+    {
+      "id": "9",
+      "type": "default",
+      "data": {
+        "label": "Initial transporter signs on paper and keeps a copy",
+        "children": [
+          "10"
+        ]
+      }
+    },
+    {
+      "id": "10",
+      "type": "default",
+      "data": {
+        "label": "Initial transporter also signs electronically",
+        "children": [
+          "11"
+        ]
+      }
+    },
+    {
+      "id": "11",
+      "type": "default",
+      "data": {
+        "label": "Subsequent transporters signs electronically",
+        "children": [
+          "12"
+        ]
+      }
+    },
+    {
+      "id": "12",
+      "type": "default",
+      "data": {
+        "label": "TSDF signs electronically",
+        "children": []
+      }
+    },
+    {
+      "id": "6",
+      "type": "default",
+      "data": {
+        "label": "Generator signs electronically",
+        "children": [
+          "13"
+        ]
+      }
+    },
+    {
+      "id": "13",
+      "type": "default",
+      "data": {
+        "label": "Transporters sign electronically",
+        "children": [
+          "14"
+        ]
+      }
+    },
+    {
+      "id": "14",
+      "type": "default",
+      "data": {
+        "label": "TSDF signs electronically",
+        "children": []
+      }
+    },
+    {
+      "id": "15",
+      "type": "BoolNode",
+      "data": {
+        "label": "Generator can sign electronically?",
+        "yesId": "16",
+        "noId": "17",
+        "children": [
+          "16",
+          "17"
+        ]
+      }
+    },
+    {
+      "id": "16",
+      "type": "default",
+      "data": {
+        "label": "TSDF updates status to Scheduled",
+        "children": [
+          "18"
+        ]
+      }
+    },
+    {
+      "id": "18",
+      "type": "default",
+      "data": {
+        "label": "Generator signs electronically",
+        "children": [
+          "19"
+        ]
+      }
+    },
+    {
+      "id": "19",
+      "type": "default",
+      "data": {
+        "label": "Generator signs electronically",
+        "children": [
+          "20"
+        ]
+      }
+    },
+    {
+      "id": "20",
+      "type": "default",
+      "data": {
+        "label": "Transporters sign electronically",
+        "children": [
+          "21"
+        ]
+      }
+    },
+    {
+      "id": "21",
+      "type": "default",
+      "data": {
+        "label": "TSDF sign electronically",
+        "children": [
+        ]
+      }
+    },
+    {
+      "id": "17",
+      "type": "default",
+      "data": {
+        "label": "TSDF selects the Hybrid Manifest option and updates status to Scheduled",
+        "children": [
+          "22"
+        ]
+      }
+    },
+    {
+      "id": "22",
+      "type": "default",
+      "data": {
+        "label": "Transporter prints 2 paper copies",
+        "children": [
+          "23"
+        ]
+      }
+    },
+    {
+      "id": "23",
+      "type": "default",
+      "data": {
+        "label": "Generator signs on paper and keeps a copy",
+        "children": [
+          "24"
+        ]
+      }
+    },
+    {
+      "id": "24",
+      "type": "default",
+      "data": {
+        "label": "Initial transporter signs on paper and keeps a copy",
+        "children": [
+          "25"
+        ]
+      }
+    },
+    {
+      "id": "25",
+      "type": "default",
+      "data": {
+        "label": "Subsequent transporters signs electronically",
+        "children": [
+          "26"
+        ]
+      }
+    },
+    {
+      "id": "26",
+      "type": "default",
+      "data": {
+        "label": "TSDF signs electronically",
+        "children": [
+        ]
+      }
     }
-  },
-  {
-    "id": "1",
-    "type": "default",
-    "data": {
-      "label": "I am a Generator or Transporter",
-      "children": [
-        "15"
-      ]
-    }
-  },
-  {
-    "id": "2",
-    "type": "default",
-    "data": {
-      "label": "I am a TSDF",
-      "children": [
-        "3"
-      ]
-    }
-  },
-  {
-    "id": "3",
-    "type": "BoolNode",
-    "data": {
-      "label": "Generator can sign electronically?",
-      "yesId": "4",
-      "noId": "5",
-      "children": [
-        "4",
-        "5"
-      ]
-    }
-  },
-  {
-    "id": "4",
-    "type": "default",
-    "data": {
-      "label": "Create a Fully Electronic Manifest and set to Scheduled",
-      "children": [
-        "6"
-      ]
-    }
-  },
-  {
-    "id": "5",
-    "type": "default",
-    "data": {
-      "label": "Create a Hybrid Manifest and set to Scheduled",
-      "children": [
-        "7"
-      ]
-    }
-  },
-  {
-    "id": "7",
-    "type": "default",
-    "data": {
-      "label": "Transporter prints 2 paper copies",
-      "children": [
-        "8"
-      ]
-    }
-  },
-  {
-    "id": "8",
-    "type": "default",
-    "data": {
-      "label": "Generator signs on paper and keeps a copy",
-      "children": [
-        "9"
-      ]
-    }
-  },
-  {
-    "id": "9",
-    "type": "default",
-    "data": {
-      "label": "Initial transporter signs on paper and keeps a copy",
-      "children": [
-        "10"
-      ]
-    }
-  },
-  {
-    "id": "10",
-    "type": "default",
-    "data": {
-      "label": "Initial transporter also signs electronically",
-      "children": [
-        "11"
-      ]
-    }
-  },
-  {
-    "id": "11",
-    "type": "default",
-    "data": {
-      "label": "Subsequent transporters signs electronically",
-      "children": [
-        "12"
-      ]
-    }
-  },
-  {
-    "id": "12",
-    "type": "default",
-    "data": {
-      "label": "TSDF signs electronically",
-      "children": []
-    }
-  },
-  {
-    "id": "6",
-    "type": "default",
-    "data": {
-      "label": "Generator signs electronically",
-      "children": [
-        "13"
-      ]
-    }
-  },
-  {
-    "id": "13",
-    "type": "default",
-    "data": {
-      "label": "Transporters sign electronically",
-      "children": [
-        "14"
-      ]
-    }
-  },
-  {
-    "id": "14",
-    "type": "default",
-    "data": {
-      "label": "TSDF signs electronically",
-      "children": []
-    }
-  },
-  {
-    "id": "15",
-    "type": "BoolNode",
-    "data": {
-      "label": "Generator can sign electronically?",
-      "yesId": "16",
-      "noId": "17",
-      "children": [
-        "16",
-        "17"
-      ]
-    }
-  },
-  {
-    "id": "16",
-    "type": "default",
-    "data": {
-      "label": "TSDF updates status to Scheduled",
-      "children": [
-        "18"
-      ]
-    }
-  },
-  {
-    "id": "18",
-    "type": "default",
-    "data": {
-      "label": "Generator signs electronically",
-      "children": [
-        "19"
-      ]
-    }
-  },
-  {
-    "id": "19",
-    "type": "default",
-    "data": {
-      "label": "Generator signs electronically",
-      "children": [
-        "20"
-      ]
-    }
-  },
-  {
-    "id": "20",
-    "type": "default",
-    "data": {
-      "label": "Transporters sign electronically",
-      "children": [
-        "21"
-      ]
-    }
-  },
-  {
-    "id": "21",
-    "type": "default",
-    "data": {
-      "label": "TSDF sign electronically",
-      "children": [
-      ]
-    }
-  },
-  {
-    "id": "17",
-    "type": "default",
-    "data": {
-      "label": "TSDF selects the Hybrid Manifest option and updates status to Scheduled",
-      "children": [
-        "22"
-      ]
-    }
-  },
-  {
-    "id": "22",
-    "type": "default",
-    "data": {
-      "label": "Transporter prints 2 paper copies",
-      "children": [
-        "23"
-      ]
-    }
-  },
-  {
-    "id": "23",
-    "type": "default",
-    "data": {
-      "label": "Generator signs on paper and keeps a copy",
-      "children": [
-        "24"
-      ]
-    }
-  },
-  {
-    "id": "24",
-    "type": "default",
-    "data": {
-      "label": "Initial transporter signs on paper and keeps a copy",
-      "children": [
-        "25"
-      ]
-    }
-  },
-  {
-    "id": "25",
-    "type": "default",
-    "data": {
-      "label": "Subsequent transporters signs electronically",
-      "children": [
-        "26"
-      ]
-    }
-  },
-  {
-    "id": "26",
-    "type": "default",
-    "data": {
-      "label": "TSDF signs electronically",
-      "children": [
-      ]
-    }
-  }
-]
+  ]
+}

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -77,6 +77,6 @@ describe('App', () => {
     server.use(http.get('/default.json', async () => HttpResponse.error()));
     render(<App />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
-    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/Error/i)).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,7 @@ export default function App() {
   const { nodes, edges, onClick } = useDecisionTree(config);
   const [mapVisible, setMapVisible] = useState(true);
 
-  if (isLoading || !config) return <Spinner />;
-
-  if (error || (!config && !isLoading)) throw new Error('Failed to fetch config');
+  if (isLoading) return <Spinner />;
 
   return (
     <>
@@ -30,7 +28,11 @@ export default function App() {
         mapVisible={mapVisible}
         setMapVisible={setMapVisible}
       />
-      <Tree nodes={nodes} edges={edges} onClick={onClick} mapVisible={mapVisible} />
+      {error ? (
+        <div>Error</div>
+      ) : (
+        <Tree nodes={nodes} edges={edges} onClick={onClick} mapVisible={mapVisible} />
+      )}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,14 @@ import { useState } from 'react';
  */
 export default function App() {
   const title = import.meta.env.VITE_APP_TITLE ?? 'The Manifest Game';
-  const { config, isLoading, error } = useFetchConfig('/default.json');
+  const {
+    config,
+    isLoading: configIsLoading,
+    error: configError,
+  } = useFetchConfig('/default.json');
   const [direction, setDirection] = useTreeDirection();
   const { nodes, edges, onClick } = useDecisionTree(config);
   const [mapVisible, setMapVisible] = useState(true);
-
-  if (isLoading) return <Spinner />;
 
   return (
     <>
@@ -29,17 +31,10 @@ export default function App() {
         mapVisible={mapVisible}
         setMapVisible={setMapVisible}
       />
-      {error ? (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignContent: 'center',
-            marginTop: '20%',
-          }}
-        >
-          <ErrorMsg />
-        </div>
+      {configIsLoading ? (
+        <Spinner />
+      ) : configError ? (
+        <ErrorMsg message={'Error parsing the Decision Tree'} />
       ) : (
         <Tree nodes={nodes} edges={edges} onClick={onClick} mapVisible={mapVisible} />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { ErrorMsg } from 'components/Error';
 import { Header } from 'components/Header/Header';
 import { Spinner } from 'components/Spinner/Spinner';
 import { Tree } from 'components/Tree/Tree';
@@ -29,7 +30,16 @@ export default function App() {
         setMapVisible={setMapVisible}
       />
       {error ? (
-        <div>Error</div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignContent: 'center',
+            marginTop: '20%',
+          }}
+        >
+          <ErrorMsg />
+        </div>
       ) : (
         <Tree nodes={nodes} edges={edges} onClick={onClick} mapVisible={mapVisible} />
       )}

--- a/src/components/Error/ErrorMsg.spec.tsx
+++ b/src/components/Error/ErrorMsg.spec.tsx
@@ -9,12 +9,14 @@ beforeAll(() => {
 beforeEach(() => {
   vi.unstubAllEnvs();
 });
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+});
 
 describe('ErrorMsg', () => {
   it('renders', () => {
     render(<ErrorMsg />);
-    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/An Error occurred/i)).toBeInTheDocument();
   });
   it('provides a configurable link to file a ticket', () => {
     const issueUrl = 'https://example.com/issues/new';
@@ -26,9 +28,13 @@ describe('ErrorMsg', () => {
     expect(issueLink).toHaveAttribute('href', issueUrl);
   });
   it('Does not render a link if environment variable is not defined', () => {
-    vi.unstubAllEnvs();
     render(<ErrorMsg />);
     const issueLink = screen.queryByRole('link', { name: 'file a ticket' });
     expect(issueLink).not.toBeInTheDocument();
+  });
+  it('renders an error message if one if passed', () => {
+    const message = 'alright meow, license and registration';
+    render(<ErrorMsg message={message} />);
+    expect(screen.getByText(message)).toBeInTheDocument();
   });
 });

--- a/src/components/Error/ErrorMsg.tsx
+++ b/src/components/Error/ErrorMsg.tsx
@@ -1,14 +1,18 @@
 import styles from './errorMsg.module.css';
 
+interface ErrorMsgProps {
+  message?: string;
+}
+
 /**
  * ErrorMsg displays a simple error message and a link to file a ticket.
  */
-export const ErrorMsg = () => {
+export const ErrorMsg = ({ message }: ErrorMsgProps) => {
   const issueURL = import.meta.env.VITE_ISSUE_URL;
   return (
     <div className={styles.center}>
       <div className={styles.errorBox}>
-        <h1>Something went wrong</h1>
+        <h2>{message ?? 'An error occurred'}</h2>
         {issueURL && (
           <p>
             <a href={issueURL} className={styles.errorLink}>

--- a/src/components/Error/errorMsg.module.css
+++ b/src/components/Error/errorMsg.module.css
@@ -30,9 +30,10 @@
 .center {
     display: flex;
     align-content: center;
+    text-align: center;
     justify-content: center;
-    margin-top: 20px;
-    margin-bottom: 20px;
-    font-size: 20px;
+    margin-top: 30%;
+    margin-bottom: 30%;
+    font-size: 1.2rem;
     font-weight: bold;
 }

--- a/src/hooks/useFetchConfig/useFetchConfig.tsx
+++ b/src/hooks/useFetchConfig/useFetchConfig.tsx
@@ -89,7 +89,6 @@ export const useFetchConfig = (configPath: string) => {
           setConfig(config);
         } catch {
           setError({ message: 'Error Parsing Config' });
-          setIsLoading(false);
         }
       })
       .catch((error) => {

--- a/src/hooks/useFetchConfig/useFetchConfig.tsx
+++ b/src/hooks/useFetchConfig/useFetchConfig.tsx
@@ -4,7 +4,8 @@ import { TreeNode } from 'store';
 import { PositionUnawareDecisionTree } from 'store/DagSlice/dagSlice';
 
 /**
- * data needed by all TreeNodes that contains the nodes expanded state, the node's children, and the node's text
+ * Data needed by all TreeNodes that contains the nodes expanded state,
+ * the node's children, and the node's text
  */
 export interface NodeData {
   label: string;
@@ -12,28 +13,26 @@ export interface NodeData {
   expanded?: boolean;
 }
 
-/**
- * data needed by the BooleanTreeNode to render decisions
- */
+/** data needed by the BooleanTreeNode to render decisions*/
 export interface BooleanNodeData extends NodeData {
   yesId: string;
   noId: string;
 }
 
-/**
- * An individual object to configure a node, part of the tree config
- */
-export interface TreeNodeConfig {
+/** Configuration for an individual node, part of the larger config*/
+export interface NodeConfig {
   id: string;
   data: NodeData | BooleanNodeData;
   type?: string;
 }
 
 /**
- * A tree config is a JSON serializable array of object that contains all the position unaware
+ * A JSON serializable array of object that contains all the position unaware
  * nodes in the decision tree, before it is loaded into the store
  */
-export type TreeConfig = Array<TreeNodeConfig>;
+export type TreeConfig = {
+  nodes: Array<NodeConfig>;
+};
 
 interface UseFetchConfigError {
   message: string;
@@ -51,7 +50,7 @@ export interface BaseConfig {
 /** Parses the config file (an array of BoolNodeConfig and DefaultNodeConfig types) and returns a DecisionTree */
 const parseConfig = (config: TreeConfig): PositionUnawareDecisionTree => {
   const tree: PositionUnawareDecisionTree = {};
-  config.forEach((node, index) => {
+  config.nodes.forEach((node, index) => {
     if (node.type === 'BoolNode') {
       const { id, data } = node;
       tree[id] = {


### PR DESCRIPTION
## Description

Adds unhappy path error handling for when the config that defines the tree is unable to be parsed or retrieved. 

## Issue ticket number and link

closes #32 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
