### PR TITLE
Fix Build Container on push to main

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -8,6 +8,14 @@ on:
         default: 'the-manifest-game'
         type: string
         description: 'The name of the image to build.'
+      image_tags:
+        default: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+        type: string
+        description: 'The tags to apply to the docker images'
 
 jobs:
   build_image:
@@ -25,6 +33,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}
+          tags: ${{ inputs.image_tags }}
 
       - name: 'Set up QEMU'
         # docker emulation library for cross-architecture images

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,4 +1,4 @@
-name: 'Deploy to Development'
+name: 'Dev Deployment'
 
 # Builds our artifact and deploy to GitHub Pages which we are using as our
 # development environment.
@@ -8,20 +8,19 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: 'pages'
-  cancel-in-progress: true
 
 jobs:
   deploy:
     if: github.repository == 'usepa/the-manifest-game'
     name: 'Deploy to Development'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: true
     environment:
       name: development
       url: ${{ steps.deployment.outputs.page_url }}
@@ -55,5 +54,8 @@ jobs:
         uses: actions/deploy-pages@v4
 
   build_container_image:
-    name: 'Build Latest Image'
+    name: 'Containerize'
     uses: ./.github/workflows/build-image.yaml
+    with:
+      image_tags: |
+        type=sha


### PR DESCRIPTION
## Description

Quick fix for our development deployment process. Now, in parallel with our dev deployment, we build and containerize the manifest game and tag it with the git SHA. 

As part of this PR's implementation, we move permissions (for github pages) to the deployment development job so other jobs can run within their needed permission scope

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
