### PR TITLE
custom hook useTreeViewport for controlling the view port

### DIFF
--- a/src/components/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.tsx
@@ -1,5 +1,5 @@
 import { BaseNode } from 'components/Nodes/BaseNode/BaseNode';
-import { useDAG } from 'hooks/useDAG/useDAG';
+import { useDagStore } from 'hooks';
 import { useState } from 'react';
 import { NodeProps } from 'reactflow';
 
@@ -17,7 +17,7 @@ export const BoolNode = ({
   id,
   ...props
 }: NodeProps<BoolNodeData>) => {
-  const { showNode, hideNode } = useDAG();
+  const { showNode, hideNode } = useDagStore();
   const [selected, setSelected] = useState<'yes' | 'no' | undefined>(undefined);
 
   const handleYes = () => {

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,7 +1,7 @@
 import { BoolNode } from 'components/Nodes/BoolNode/BoolNode';
 import { DefaultNode } from 'components/Nodes/DefaultNode/DefaultNode';
 import { ControlCenter } from 'components/Tree/ControlCenter';
-import { useDAG, useTreeDirection } from 'hooks';
+import { useDagStore, useTreeDirection } from 'hooks';
 import React, { useMemo, useState } from 'react';
 import ReactFlow, {
   Edge,
@@ -25,7 +25,7 @@ export interface TreeProps {
  */
 export const Tree = ({ nodes, edges, onClick }: TreeProps) => {
   const nodeTypes = useMemo(() => ({ BoolNode: BoolNode, default: DefaultNode }), []);
-  const { onNodesChange, onEdgesChange } = useDAG();
+  const { onNodesChange, onEdgesChange } = useDagStore();
   const [mapVisible, setMapVisible] = useState(true);
   const [direction, setDirection] = useTreeDirection();
   const { setCenter } = useReactFlow();

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,4 @@
 export { useDecisionTree } from './useDecisionTree/useDecisionTree';
-export { useDAG } from './useDAG/useDAG';
+export { useDagStore } from 'hooks/useDagStore/useDagStore';
 export { useFetchConfig } from './useFetchConfig/useFetchConfig';
 export { useTreeDirection } from './useTreeDirection/useTreeDirection';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useDecisionTree } from './useDecisionTree/useDecisionTree';
-export { useDagStore } from 'hooks/useDagStore/useDagStore';
+export { useDagStore } from './useDagStore/useDagStore';
 export { useFetchConfig } from './useFetchConfig/useFetchConfig';
 export { useTreeDirection } from './useTreeDirection/useTreeDirection';
+export { useTreeViewport } from './useTreeViewport/useTreeViewport';

--- a/src/hooks/useDagStore/useDagStore.spec.tsx
+++ b/src/hooks/useDagStore/useDagStore.spec.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useDAG } from 'hooks/useDAG/useDAG';
+import { useDagStore } from 'hooks/useDagStore/useDagStore';
 import { DecisionTree } from 'store';
 import { afterEach, describe, expect, test } from 'vitest';
 
@@ -14,7 +14,7 @@ interface TestComponentProps {
 }
 
 const TestComponent = ({ initialTree, hideNodeId = '1', showNodeId = '1' }: TestComponentProps) => {
-  const { tree, hideNode, showNode } = useDAG(initialTree);
+  const { tree, hideNode, showNode } = useDagStore(initialTree);
 
   return (
     <>
@@ -29,7 +29,7 @@ const TestComponent = ({ initialTree, hideNodeId = '1', showNodeId = '1' }: Test
   );
 };
 
-describe('useTreeNodes', () => {
+describe('useDagStore', () => {
   test('accepts a initial DecisionTree and updates the store', () => {
     const initialTree: DecisionTree = {
       '1': {

--- a/src/hooks/useDagStore/useDagStore.spec.tsx
+++ b/src/hooks/useDagStore/useDagStore.spec.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDagStore } from 'hooks/useDagStore/useDagStore';
+import { ReactFlowProvider } from 'reactflow';
 import { DecisionTree } from 'store';
 import { afterEach, describe, expect, test } from 'vitest';
 
@@ -39,7 +40,11 @@ describe('useDagStore', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(<TestComponent initialTree={initialTree} />);
+    render(
+      <ReactFlowProvider>
+        <TestComponent initialTree={initialTree} />
+      </ReactFlowProvider>
+    );
     expect(screen.getByText(/node id: 1/i)).toBeInTheDocument();
   });
   test('hideNode hides a node in the tree from view', async () => {
@@ -52,7 +57,11 @@ describe('useDagStore', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(<TestComponent initialTree={initialTree} />);
+    render(
+      <ReactFlowProvider>
+        <TestComponent initialTree={initialTree} />
+      </ReactFlowProvider>
+    );
     expect(screen.getByText(/node id: 1/i)).toBeInTheDocument();
     await user.click(screen.getByText(/hide node/i));
     expect(screen.queryByText(/node id: 1/i)).not.toBeInTheDocument();
@@ -75,7 +84,11 @@ describe('useDagStore', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(<TestComponent initialTree={initialTree} showNodeId={childId} />);
+    render(
+      <ReactFlowProvider>
+        <TestComponent initialTree={initialTree} showNodeId={childId} />
+      </ReactFlowProvider>
+    );
     expect(screen.queryByText(/node id: 2/i)).not.toBeInTheDocument();
     await user.click(screen.getByText(/show node/i));
     expect(screen.queryByText(/node id: 2/i)).toBeInTheDocument();

--- a/src/hooks/useDagStore/useDagStore.tsx
+++ b/src/hooks/useDagStore/useDagStore.tsx
@@ -1,5 +1,5 @@
+import { useTreeViewport } from 'hooks/useTreeViewport/useTreeViewport';
 import { useEffect } from 'react';
-import { useReactFlow } from 'reactflow';
 import useStore from 'store';
 import { PositionUnawareDecisionTree, ShowDagNodeOptions } from 'store/DagSlice/dagSlice';
 
@@ -11,7 +11,7 @@ import { PositionUnawareDecisionTree, ShowDagNodeOptions } from 'store/DagSlice/
  * @param initialTree
  */
 export const useDagStore = (initialTree?: PositionUnawareDecisionTree) => {
-  const { setCenter, getZoom } = useReactFlow();
+  const { setCenter, getZoom } = useTreeViewport();
   const {
     decisionTree,
     setDecisionTree: setTree,

--- a/src/hooks/useDagStore/useDagStore.tsx
+++ b/src/hooks/useDagStore/useDagStore.tsx
@@ -9,7 +9,7 @@ import { PositionUnawareDecisionTree, ShowDagNodeOptions } from 'store/DagSlice/
  * such as showing and hiding nodes and edges
  * @param initialTree
  */
-export const useDAG = (initialTree?: PositionUnawareDecisionTree) => {
+export const useDagStore = (initialTree?: PositionUnawareDecisionTree) => {
   const {
     decisionTree,
     setDecisionTree: setTree,

--- a/src/hooks/useDagStore/useDagStore.tsx
+++ b/src/hooks/useDagStore/useDagStore.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useReactFlow } from 'reactflow';
 import useStore from 'store';
 import { PositionUnawareDecisionTree, ShowDagNodeOptions } from 'store/DagSlice/dagSlice';
 
@@ -10,6 +11,7 @@ import { PositionUnawareDecisionTree, ShowDagNodeOptions } from 'store/DagSlice/
  * @param initialTree
  */
 export const useDagStore = (initialTree?: PositionUnawareDecisionTree) => {
+  const { setCenter, getZoom } = useReactFlow();
   const {
     decisionTree,
     setDecisionTree: setTree,
@@ -27,6 +29,7 @@ export const useDagStore = (initialTree?: PositionUnawareDecisionTree) => {
   /** show a node's direct children and the edges leading to them */
   const showChildren = (nodeId: string) => {
     showDagChildren(nodeId);
+    setCenter(decisionTree[nodeId].position.x, decisionTree[nodeId].position.y);
   };
 
   /** hide a node's descendant nodes and edges, but not the node itself */
@@ -48,6 +51,10 @@ export const useDagStore = (initialTree?: PositionUnawareDecisionTree) => {
   /** show a node and the edge leading to it */
   const showNode = (nodeId: string, options?: ShowDagNodeOptions) => {
     showDagNode(nodeId, options);
+    setCenter(decisionTree[nodeId].position.x + 50, decisionTree[nodeId].position.y + 50, {
+      zoom: getZoom(),
+      duration: 1000,
+    });
   };
 
   useEffect(() => {

--- a/src/hooks/useDecisionTree/useDecisionTree.spec.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { useDecisionTree } from 'hooks/useDecisionTree/useDecisionTree';
+import { ReactFlowProvider } from 'reactflow';
 import { DecisionTree } from 'store';
 import { afterEach, describe, expect, test } from 'vitest';
 
@@ -39,7 +40,11 @@ describe('useDecisionTree', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(<TestComponent initialTree={myNodes} />);
+    render(
+      <ReactFlowProvider>
+        <TestComponent initialTree={myNodes} />
+      </ReactFlowProvider>
+    );
     expect(screen.getByText('id: 1')).toBeInTheDocument();
     expect(screen.queryByText('2')).not.toBeInTheDocument();
   });

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -1,6 +1,6 @@
-import { useDAG } from 'hooks/useDAG/useDAG';
+import { useDagStore } from 'hooks';
 import { NodeMouseHandler } from 'reactflow';
-import { PositionUnawareDecisionTree } from 'store/DagSlice/dagSlice';
+import { PositionUnawareDecisionTree } from 'store';
 
 /**
  * useDecisionTree
@@ -9,7 +9,7 @@ import { PositionUnawareDecisionTree } from 'store/DagSlice/dagSlice';
  * @param initialTree
  */
 export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
-  const { hideDescendants, showChildren, edges, nodes, hideNiblings } = useDAG(initialTree);
+  const { hideDescendants, showChildren, edges, nodes, hideNiblings } = useDagStore(initialTree);
 
   /** handle node click events */
   const onClick: NodeMouseHandler = (_event, node) => {

--- a/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
@@ -7,13 +7,27 @@ import { afterEach, describe, expect, it } from 'vitest';
 afterEach(() => {
   cleanup();
 });
-const TestComponent = () => {
-  const { x, y, zoom } = useTreeViewport();
+const TestComponent = ({
+  xInput,
+  yInput,
+  zoomInput,
+}: {
+  xInput?: number;
+  yInput?: number;
+  zoomInput?: number;
+}) => {
+  const { x, y, zoom, setCenter } = useTreeViewport();
+  const cleanedX = xInput ?? 1;
+  const cleanedY = yInput ?? 1;
+  const cleanedZoom = zoomInput ?? 1;
   return (
     <>
       <p>{`x: ${x}`}</p>
       <p>{`y: ${y}`}</p>
       <p>{`zoom: ${zoom}`}</p>
+      <button onClick={() => setCenter(cleanedX, cleanedY, { zoom: cleanedZoom })}>
+        Set Center
+      </button>
     </>
   );
 };

--- a/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import { cleanup, render, screen } from '@testing-library/react';
+import { useTreeViewport } from 'hooks/useTreeViewport/useTreeViewport';
+import { ReactFlowProvider } from 'reactflow';
+import { afterEach, describe, expect, it } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+const TestComponent = () => {
+  const { x, y, zoom } = useTreeViewport();
+  return (
+    <>
+      <p>{`x: ${x}`}</p>
+      <p>{`y: ${y}`}</p>
+      <p>{`zoom: ${zoom}`}</p>
+    </>
+  );
+};
+
+describe('useTreeViewport', () => {
+  it('returns the current x, y, and zoom', () => {
+    render(
+      <ReactFlowProvider>
+        <TestComponent />
+      </ReactFlowProvider>
+    );
+    expect(screen.getByText(/x: \d+/i)).toBeInTheDocument();
+    expect(screen.getByText(/y: \d+/i)).toBeInTheDocument();
+    expect(screen.getByText(/zoom: \d+/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useTreeViewport/useTreeViewport.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.tsx
@@ -5,7 +5,7 @@ import { useReactFlow, useViewport } from 'reactflow';
  */
 export const useTreeViewport = () => {
   const { x, y, zoom } = useViewport();
-  const { setCenter: setFlowCenter } = useReactFlow();
+  const { setCenter: setFlowCenter, getZoom } = useReactFlow();
 
   const setCenter = (
     xInput: number,
@@ -18,5 +18,5 @@ export const useTreeViewport = () => {
     setFlowCenter(xInput, yInput, options);
   };
 
-  return { x, y, zoom, setCenter } as const;
+  return { x, y, zoom, setCenter, getZoom } as const;
 };

--- a/src/hooks/useTreeViewport/useTreeViewport.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.tsx
@@ -5,7 +5,18 @@ import { useReactFlow, useViewport } from 'reactflow';
  */
 export const useTreeViewport = () => {
   const { x, y, zoom } = useViewport();
-  const { setCenter } = useReactFlow();
+  const { setCenter: setFlowCenter } = useReactFlow();
+
+  const setCenter = (
+    xInput: number,
+    yInput: number,
+    options?: {
+      duration?: number;
+      zoom?: number;
+    }
+  ) => {
+    setFlowCenter(xInput, yInput, options);
+  };
 
   return { x, y, zoom, setCenter } as const;
 };

--- a/src/hooks/useTreeViewport/useTreeViewport.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.tsx
@@ -1,0 +1,11 @@
+import { useReactFlow, useViewport } from 'reactflow';
+
+/**
+ * Returns the current position and a setter
+ */
+export const useTreeViewport = () => {
+  const { x, y, zoom } = useViewport();
+  const { setCenter } = useReactFlow();
+
+  return { x, y, zoom, setCenter } as const;
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,12 @@ import { createDagSlice, DagSlice } from 'store/DagSlice/dagSlice';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-export type { DecisionTree, TreeNode, DagNode } from 'store/DagSlice/dagSlice';
+export type {
+  DecisionTree,
+  TreeNode,
+  DagNode,
+  PositionUnawareDecisionTree,
+} from 'store/DagSlice/dagSlice';
 
 export const useStore = create<DagSlice>()(
   devtools(


### PR DESCRIPTION
## Description
implements a new hook that wraps around the react flow library's hook exports and allows us to pan the viewport as the user selects the node options. 

## Issue ticket number and link

closes #59 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
