### PR TITLE
Fix duplicate edge

### DIFF
--- a/public/default.json
+++ b/public/default.json
@@ -1,7 +1,7 @@
 {
   "nodes": [
     {
-      "id": "parent",
+      "id": "root",
       "type": "BoolNode",
       "data": {
         "label": "Are you registered?",

--- a/src/store/DagSlice/dagSlice.ts
+++ b/src/store/DagSlice/dagSlice.ts
@@ -10,6 +10,7 @@ import {
   OnNodesChange,
 } from 'reactflow';
 import {
+  addDagEdge,
   applyPositionToNodes,
   createDagEdge,
   createDagNode,
@@ -127,12 +128,14 @@ export const createDagSlice: StateCreator<DagSlice, [['zustand/devtools', never]
   },
   showDagNode: (nodeId: string, options?: ShowDagNodeOptions) => {
     const decisionTree = setNodeVisible(get().decisionTree, nodeId);
-    const dagEdges = get().dagEdges;
+    const dagEdges = options?.parentId
+      ? addDagEdge(get().dagEdges, {
+          source: options.parentId,
+          target: nodeId,
+        })
+      : get().dagEdges;
     const dagNodes = removeNodes(get().dagNodes, [nodeId]);
     const newNode = createDagNode(nodeId, decisionTree[nodeId]);
-    if (options?.parentId) {
-      dagEdges.push(createDagEdge(options.parentId, nodeId));
-    }
     set(
       {
         decisionTree,

--- a/src/store/DagSlice/dagUtils.spec.ts
+++ b/src/store/DagSlice/dagUtils.spec.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom';
+import { Edge } from 'reactflow';
 import { DecisionTree } from 'store/DagSlice/dagSlice';
-import { applyPositionToNodes, createDagEdge, getSiblingIds } from 'store/DagSlice/dagUtils';
+import {
+  addDagEdge,
+  applyPositionToNodes,
+  createDagEdge,
+  getSiblingIds,
+} from 'store/DagSlice/dagUtils';
 import { describe, expect, it, test } from 'vitest';
 
 describe('Dag Slice internal functions', () => {
@@ -90,5 +96,15 @@ describe('Dag Slice internal functions', () => {
     ];
     const nodesWithPositions = applyPositionToNodes(tree, existingNodes);
     expect(nodesWithPositions[0].position).toEqual({ x: newX, y: newY });
+  });
+  it('adding an edge is idempotent', () => {
+    const id1 = '1';
+    const id2 = '2';
+    const id3 = '3';
+    const currentEdges: Edge[] = [{ ...createDagEdge(id1, id2) }, { ...createDagEdge(id2, id3) }];
+    const nonUpdatedEdges = addDagEdge(currentEdges, { source: id1, target: id2 });
+    expect(nonUpdatedEdges).toEqual(currentEdges);
+    const updatedEdges = addDagEdge(currentEdges, { source: id1, target: id3 });
+    expect(updatedEdges.length).toBe(currentEdges.length + 1);
   });
 });

--- a/src/store/DagSlice/dagUtils.ts
+++ b/src/store/DagSlice/dagUtils.ts
@@ -6,6 +6,19 @@
 import { Edge, MarkerType } from 'reactflow';
 import { DagNode, DecisionTree, TreeNode } from './dagSlice';
 
+export interface DagEdgeConfig {
+  source: string;
+  target: string;
+}
+
+/** idempotent action to add an edge */
+export const addDagEdge = (currentEdges: Edge[], config: DagEdgeConfig) => {
+  if (currentEdges.find((e) => e.source === config.source && e.target === config.target)) {
+    return currentEdges;
+  }
+  return [...currentEdges, createDagEdge(config.source, config.target)];
+};
+
 /** creates the edges between two nodes with defaults applied */
 export const createDagEdge = (source: string, target: string): Edge => {
   return {


### PR DESCRIPTION
## Description

Fixes an issue where if a selection is made multiple times, an additional edge was added to the store with an identical ID to the edge created from the previous selection. The edges were removed from the store but the react UI was unable to update since the ID is used as the key in the react components (multiple objects with the same key problem). 

## Issue ticket number and link

closes #30 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
