### PR TITLE
Edge slice

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
   schedule:
     - cron: '32 7 * * 3'
 

--- a/public/default.json
+++ b/public/default.json
@@ -12,7 +12,23 @@
     {
       "id": "goRegister",
       "data": {
-        "label": "Time to Register in RCRAInfo!"
+        "label": "Time to Register in RCRAInfo!",
+        "children": [
+          "test1",
+          "test2"
+        ]
+      }
+    },
+    {
+      "id": "test1",
+      "data": {
+        "label": "Test 1"
+      }
+    },
+    {
+      "id": "test2",
+      "data": {
+        "label": "Test 2"
       }
     },
     {

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -5,7 +5,7 @@ import { delay, http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import React from 'react';
 import { ReactFlowProvider } from 'reactflow';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 const TestComponent = () => {
   return (
@@ -45,7 +45,7 @@ afterAll(() => {
 });
 
 describe('App', () => {
-  it('shows a spinner while waiting for config', () => {
+  test('shows a spinner while waiting for config', () => {
     server.use(
       http.get('/default.json', async () => {
         await delay(100);
@@ -66,24 +66,24 @@ describe('App', () => {
     render(<TestComponent />);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
-  it('renders a title if provided', async () => {
+  test('renders a title if provided', async () => {
     const title = 'Zee bananas';
     vi.stubEnv('VITE_APP_TITLE', title);
     render(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByText(title)).toBeInTheDocument();
   });
-  it('defaults title to "The Manifest Game"', async () => {
+  test('defaults title to "The Manifest Game"', async () => {
     render(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByText('The Manifest Game')).toBeInTheDocument();
   });
-  it('minimap is visible by default', async () => {
+  test('minimap is visible by default', async () => {
     render(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByTestId(/minimap/i)).toBeInTheDocument();
   });
-  it('Throws an error if there is an error fetching the config', async () => {
+  test('Throws an error if there is an error fetching the config', async () => {
     server.use(http.get('/default.json', async () => HttpResponse.error()));
     render(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());

--- a/src/components/Error/ErrorBoundary.spec.tsx
+++ b/src/components/Error/ErrorBoundary.spec.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { ErrorBoundary } from 'components/Error/ErrorBoundary';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 afterEach(() => cleanup());
 
@@ -12,7 +12,7 @@ const ErrorComponent = ({ error = false }: { error?: boolean }) => {
 };
 
 describe('ErrorBoundary', () => {
-  it('renders children without error', () => {
+  test('renders children without error', () => {
     render(
       <ErrorBoundary fallback={<div>error</div>}>
         <ErrorComponent />
@@ -20,7 +20,7 @@ describe('ErrorBoundary', () => {
     );
     expect(screen.getByText(/no error/i)).toBeInTheDocument();
   });
-  it('renders fallback on error', () => {
+  test('renders fallback on error', () => {
     vi.spyOn(console, 'error').mockImplementation(() => null);
     render(
       <ErrorBoundary fallback={<div>error</div>}>

--- a/src/components/Error/ErrorMsg.spec.tsx
+++ b/src/components/Error/ErrorMsg.spec.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { ErrorMsg } from 'components/Error/ErrorMsg';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 beforeAll(() => {
   vi.stubEnv('VITE_ISSUE_URL', 'https://example.com/issues/new');
@@ -14,11 +14,11 @@ afterEach(() => {
 });
 
 describe('ErrorMsg', () => {
-  it('renders', () => {
+  test('renders', () => {
     render(<ErrorMsg />);
     expect(screen.getByText(/An Error occurred/i)).toBeInTheDocument();
   });
-  it('provides a configurable link to file a ticket', () => {
+  test('provides a configurable link to file a ticket', () => {
     const issueUrl = 'https://example.com/issues/new';
     vi.stubEnv('VITE_ISSUE_URL', issueUrl);
     render(<ErrorMsg />);
@@ -27,12 +27,12 @@ describe('ErrorMsg', () => {
     expect(issueLink).toHaveAccessibleName('file a ticket');
     expect(issueLink).toHaveAttribute('href', issueUrl);
   });
-  it('Does not render a link if environment variable is not defined', () => {
+  test('Does not render a link if environment variable is not defined', () => {
     render(<ErrorMsg />);
     const issueLink = screen.queryByRole('link', { name: 'file a ticket' });
     expect(issueLink).not.toBeInTheDocument();
   });
-  it('renders an error message if one if passed', () => {
+  test('renders an error message if one if passed', () => {
     const message = 'alright meow, license and registration';
     render(<ErrorMsg message={message} />);
     expect(screen.getByText(message)).toBeInTheDocument();

--- a/src/components/Header/Header.spec.tsx
+++ b/src/components/Header/Header.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { Header } from './Header';
 
 const TestComponent = ({ title }: { title?: string }) => {
@@ -9,7 +9,7 @@ const TestComponent = ({ title }: { title?: string }) => {
 
 describe('Header', () => {
   afterEach(() => cleanup());
-  it('renders a title', () => {
+  test('renders a title', () => {
     const title = 'hello';
     render(<TestComponent title={title} />);
     expect(screen.getByText(title)).toBeInTheDocument();

--- a/src/components/Nodes/BaseNode/BaseNode.spec.tsx
+++ b/src/components/Nodes/BaseNode/BaseNode.spec.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, render, screen } from '@testing-library/react';
 import { BaseNode } from 'components/Nodes/BaseNode/BaseNode';
 import { ReactFlowProvider } from 'reactflow';
 import useTreeStore from 'store';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 const TestComponent = () => {
   return (
@@ -26,11 +26,11 @@ const TestComponent = () => {
 
 describe('BaseNode', () => {
   afterEach(() => cleanup());
-  it('renders', () => {
+  test('renders', () => {
     render(<TestComponent />);
     expect(screen.getByTestId('node-1')).toBeInTheDocument();
   });
-  it('handles changes in tree layout', () => {
+  test('handles changes in tree layout', () => {
     useTreeStore.setState({ direction: 'LR' });
     const { rerender } = render(<TestComponent />);
     expect(screen.getByTestId('left-handle')).toBeInTheDocument();

--- a/src/components/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.spec.tsx
@@ -1,12 +1,12 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BoolNode, BoolNodeData } from 'components/Nodes/BoolNode/BoolNode';
 import { NodeProps, ReactFlowProvider } from 'reactflow';
 import useTreeStore from 'store';
 import { afterEach, describe, expect, it } from 'vitest';
 
-afterEach(() => {});
+afterEach(() => cleanup());
 
 interface TestComponentProps {
   overwrites?: Partial<NodeProps<BoolNodeData>>;

--- a/src/components/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { BoolNode, BoolNodeData } from 'components/Nodes/BoolNode/BoolNode';
 import { NodeProps, ReactFlowProvider } from 'reactflow';
 import useTreeStore from 'store';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => cleanup());
 
@@ -68,22 +68,22 @@ const TestComponent = ({ overwrites, primaryId, noId, yesId }: TestComponentProp
 };
 
 describe('BoolNode', () => {
-  it('renders a node', () => {
+  test('renders a node', () => {
     const label = 'what site type?';
     // @ts-expect-error - don't need to pass all props
     render(<TestComponent overwrites={{ data: { label } }} />);
     expect(screen.getByText(label)).toBeInTheDocument();
   });
-  it('renders a yes and no button', () => {
+  test('renders a yes and no button', () => {
     render(<TestComponent />);
     expect(screen.getByRole('button', { name: /yes/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /no/i })).toBeInTheDocument();
   });
-  it('yes and no initially do not have selected class name', () => {
+  test('yes and no initially do not have selected class name', () => {
     render(<TestComponent />);
     expect(screen.getByRole('button', { name: /yes/i })).not.toHaveClass(/selected/i);
   });
-  it('clicking the buttons adds selected class', async () => {
+  test('clicking the buttons adds selected class', async () => {
     const user = userEvent.setup();
     render(<TestComponent />);
     const yesButton = screen.getByRole('button', { name: /yes/i });
@@ -94,7 +94,7 @@ describe('BoolNode', () => {
     expect(noButton).toHaveClass(/selected/i);
     expect(yesButton).not.toHaveClass(/selected/i);
   });
-  it('clicking yes/no toggles the visibility of the children nodes', async () => {
+  test('clicking yes/no toggles the visibility of the children nodes', async () => {
     const user = userEvent.setup();
     const primaryId = '1';
     const yesId = '2';

--- a/src/components/Nodes/DefaultNode/DefaultNode.spec.tsx
+++ b/src/components/Nodes/DefaultNode/DefaultNode.spec.tsx
@@ -1,13 +1,13 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { ReactFlowProvider } from 'reactflow';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { DefaultNode } from './DefaultNode';
 
 afterEach(() => cleanup());
 
 describe('DefaultNode', () => {
-  it('renders a node with text', () => {
+  test('renders a node with text', () => {
     const myLabel = 'what site type?';
     render(
       <ReactFlowProvider>

--- a/src/components/Spinner/Spinner.spec.tsx
+++ b/src/components/Spinner/Spinner.spec.tsx
@@ -1,12 +1,12 @@
 import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { Spinner } from 'components/Spinner/Spinner';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => cleanup());
 
 describe('Spinner', () => {
-  it('renders a spinner', () => {
+  test('renders a spinner', () => {
     render(<Spinner />);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });

--- a/src/components/Tree/ControlCenter/ControlCenter.spec.tsx
+++ b/src/components/Tree/ControlCenter/ControlCenter.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { ControlCenter } from 'components/Tree/ControlCenter/index';
 import { ReactFlowProvider } from 'reactflow';
 import { TreeDirection } from 'store';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 interface TestComponentProps {
   mapVisible?: boolean;
@@ -35,15 +35,15 @@ const TestComponent = ({ ...props }: TestComponentProps) => {
 afterEach(() => cleanup());
 
 describe('ControlCenter', () => {
-  it('renders', () => {
+  test('renders', () => {
     render(<TestComponent />);
     expect(screen.getByTestId('controlCenter')).toBeInTheDocument();
   });
-  it('renders a map toggle button', () => {
+  test('renders a map toggle button', () => {
     render(<TestComponent />);
     expect(screen.getByRole('button', { name: /minimap/i })).toBeInTheDocument();
   });
-  it('toggles the minimap visibility', async () => {
+  test('toggles the minimap visibility', async () => {
     const user = userEvent.setup();
     const setMapVisible = vi.fn();
     const { rerender } = render(<TestComponent mapVisible={true} setMapVisible={setMapVisible} />);
@@ -53,11 +53,11 @@ describe('ControlCenter', () => {
     await user.click(screen.getByRole('button', { name: /minimap/i }));
     expect(setMapVisible).toHaveBeenCalled();
   });
-  it('renders a layout toggle button', () => {
+  test('renders a layout toggle button', () => {
     render(<TestComponent />);
     expect(screen.getByRole('button', { name: /layout/i })).toBeInTheDocument();
   });
-  it('toggles the layout direction', async () => {
+  test('toggles the layout direction', async () => {
     const user = userEvent.setup();
     const setDirection = vi.fn();
     const { rerender } = render(<TestComponent setDirection={setDirection} direction={'LR'} />);

--- a/src/components/Tree/ControlCenter/Controls/LayoutBtn/LayoutBtn.spec.tsx
+++ b/src/components/Tree/ControlCenter/Controls/LayoutBtn/LayoutBtn.spec.tsx
@@ -2,22 +2,22 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LayoutBtn } from 'components/Tree/ControlCenter/Controls/LayoutBtn/LayoutBtn';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 describe('LayoutBtn', () => {
-  it('should render with initial layout direction', () => {
+  test('should render with initial layout direction', () => {
     const toggleDirection = vi.fn();
     render(<LayoutBtn isHorizontal={true} toggleDirection={toggleDirection} />);
     expect(screen.getByRole('button', { name: /switch to vertical layout/i })).toBeInTheDocument();
   });
-  it('should toggle layout direction on click', async () => {
+  test('should toggle layout direction on click', async () => {
     const user = userEvent.setup();
     const toggleDirection = vi.fn();
     render(<LayoutBtn isHorizontal={true} toggleDirection={toggleDirection} />);
     await user.click(screen.getByRole('button', { name: /switch to vertical layout/i }));
     expect(toggleDirection).toHaveBeenCalled();
   });
-  it('should update aria-label when layout direction changes', () => {
+  test('should update aria-label when layout direction changes', () => {
     const toggleDirection = vi.fn();
     const { rerender } = render(
       <LayoutBtn isHorizontal={true} toggleDirection={toggleDirection} />

--- a/src/components/Tree/ControlCenter/Controls/MiniMapBtn/MiniMapBtn.spec.tsx
+++ b/src/components/Tree/ControlCenter/Controls/MiniMapBtn/MiniMapBtn.spec.tsx
@@ -2,22 +2,22 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MiniMapBtn } from 'components/Tree/ControlCenter/Controls/MiniMapBtn/MiniMapBtn';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 describe('Minimap', () => {
-  it('render', () => {
+  test('render', () => {
     const toggleDirection = vi.fn();
     render(<MiniMapBtn visible={true} onClick={toggleDirection} />);
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
-  it('should toggle layout direction on click', async () => {
+  test('should toggle layout direction on click', async () => {
     const user = userEvent.setup();
     const toggleDirection = vi.fn();
     render(<MiniMapBtn visible={true} onClick={toggleDirection} />);
     await user.click(screen.getByRole('button'));
     expect(toggleDirection).toHaveBeenCalled();
   });
-  it('should update aria-label when map is not visible', () => {
+  test('should update aria-label when map is not visible', () => {
     const toggleDirection = vi.fn();
     const { rerender } = render(<MiniMapBtn visible={true} onClick={toggleDirection} />);
     expect(screen.getByLabelText(/hide/i)).toBeInTheDocument();

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -4,7 +4,7 @@ import { Tree } from 'components/Tree/Tree';
 import { useDecisionTree } from 'hooks';
 import { ReactFlowProvider } from 'reactflow';
 import { DecisionTree, PositionUnawareDecisionTree } from 'store';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => cleanup());
 
@@ -42,7 +42,7 @@ const TestComponent = ({ tree }: { tree?: PositionUnawareDecisionTree }) => {
 };
 
 describe('Tree Component', () => {
-  it('renders', () => {
+  test('renders', () => {
     render(
       <ReactFlowProvider>
         <Tree nodes={[]} edges={[]} onClick={() => undefined} />
@@ -50,7 +50,7 @@ describe('Tree Component', () => {
     );
     expect(screen.getByTestId('decision-tree')).toBeInTheDocument();
   });
-  it('onClick shows children nodes of unexpanded node', () => {
+  test('onClick shows children nodes of unexpanded node', () => {
     const parentId = '1';
     const childId2 = '2';
     const childId3 = '3';
@@ -93,7 +93,7 @@ describe('Tree Component', () => {
     expect(screen.queryByTestId(`node-${childId2}`)).toBeInTheDocument();
     expect(screen.queryByTestId(`node-${childId3}`)).toBeInTheDocument();
   });
-  it('hides niblings (the descendants of children) on click', () => {
+  test('hides niblings (the descendants of children) on click', () => {
     const parentId = '1';
     const siblingWithChild2 = '2';
     const sibling3 = '3';
@@ -147,7 +147,7 @@ describe('Tree Component', () => {
     fireEvent.click(screen.queryByTestId(`node-${siblingWithChild2}`)!);
     expect(screen.queryByTestId(`node-${grandchildId}`)).not.toBeInTheDocument();
   });
-  it('hides all descendants of expanded nodes on click', () => {
+  test('hides all descendants of expanded nodes on click', () => {
     const parentId = '1';
     const childId = '2';
     const grandchildId = '3';
@@ -206,7 +206,7 @@ describe('Tree Component', () => {
       expect(screen.queryByTestId(`node-${nodeId}`)).not.toBeInTheDocument();
     });
   });
-  it('ignores yes/no clicks', () => {
+  test('ignores yes/no clicks', () => {
     const parentId = '1';
     const childId = '2';
     const tree: DecisionTree = {

--- a/src/hooks/useTreeDirection/useTreeDirection.spec.tsx
+++ b/src/hooks/useTreeDirection/useTreeDirection.spec.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useTreeDirection } from 'hooks/useTreeDirection/useTreeDirection';
 import useTreeStore, { TreeDirection } from 'store';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 afterEach(() => {
   cleanup();
@@ -43,18 +43,18 @@ const TestComponent = ({
 };
 
 describe('useTreeDirection', () => {
-  it('returns the current direction', () => {
+  test('returns the current direction', () => {
     render(<TestComponent initialDir={'TB'} />);
     expect(screen.getByText('TB')).toBeInTheDocument();
   });
-  it('sets the tree direction', async () => {
+  test('sets the tree direction', async () => {
     const user = userEvent.setup();
     render(<TestComponent initialDir={'TB'} newDir={'LR'} />);
     const button = screen.getByText('set direction');
     await user.click(button);
     expect(screen.queryByText('LR')).toBeInTheDocument();
   });
-  it('exposes a boolean that indicates whether the tree layout is horizontal', async () => {
+  test('exposes a boolean that indicates whether the tree layout is horizontal', async () => {
     const user = userEvent.setup();
     render(<TestComponent initialDir={'LR'} newDir={'TB'} />);
     expect(screen.queryByText('horizontal')).toBeInTheDocument();

--- a/src/hooks/useTreeStore/useTreeStore.tsx
+++ b/src/hooks/useTreeStore/useTreeStore.tsx
@@ -26,7 +26,6 @@ export const useTreeStore = (initialTree?: PositionUnawareDecisionTree) => {
   /** show a node's direct children and the edges leading to them */
   const showChildren = (nodeId: string) => {
     showStoreChildren(nodeId);
-    setCenter(tree[nodeId].position.x, tree[nodeId].position.y);
   };
 
   /** hide a node's descendant nodes and edges, but not the node itself */

--- a/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
+++ b/src/hooks/useTreeViewport/useTreeViewport.spec.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { useTreeViewport } from 'hooks/useTreeViewport/useTreeViewport';
 import { ReactFlowProvider } from 'reactflow';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => {
   cleanup();
@@ -33,7 +33,7 @@ const TestComponent = ({
 };
 
 describe('useTreeViewport', () => {
-  it('returns the current x, y, and zoom', () => {
+  test('returns the current x, y, and zoom', () => {
     render(
       <ReactFlowProvider>
         <TestComponent />

--- a/src/store/DagEdgeSlice/dagEdgeSlice.ts
+++ b/src/store/DagEdgeSlice/dagEdgeSlice.ts
@@ -1,0 +1,31 @@
+import { applyEdgeChanges, Edge, EdgeChange, OnEdgesChange } from 'reactflow';
+import { StateCreator } from 'zustand';
+
+interface DagEdgeSliceState {
+  dagEdges: Edge[];
+}
+
+interface DagEdgeSliceActions {
+  /** Used to apply update to existing edges - used by the react-flow library*/
+  onEdgesChange: OnEdgesChange;
+}
+
+export interface DagEdgeSlice extends DagEdgeSliceState, DagEdgeSliceActions {}
+
+export const createDagEdgeSlice: StateCreator<
+  DagEdgeSlice,
+  [['zustand/devtools', never]],
+  [],
+  DagEdgeSlice
+> = (set, get) => ({
+  dagEdges: [],
+  onEdgesChange: (changes: EdgeChange[]) => {
+    set(
+      {
+        dagEdges: applyEdgeChanges(changes, get().dagEdges),
+      },
+      false,
+      'onEdgesChange'
+    );
+  },
+});

--- a/src/store/DagEdgeSlice/dagEdgeSlice.ts
+++ b/src/store/DagEdgeSlice/dagEdgeSlice.ts
@@ -24,6 +24,7 @@ export const createDagEdgeSlice: StateCreator<
   DagEdgeSlice
 > = (set, get) => ({
   dagEdges: [],
+  /* v8 ignore next 9  - this is something needed by the React flow library, not tested by us*/
   onEdgesChange: (changes: EdgeChange[]) => {
     set(
       {

--- a/src/store/DagEdgeSlice/dagEdgeSlice.ts
+++ b/src/store/DagEdgeSlice/dagEdgeSlice.ts
@@ -8,6 +8,8 @@ interface DagEdgeSliceState {
 interface DagEdgeSliceActions {
   /** Used to apply update to existing edges - used by the react-flow library*/
   onEdgesChange: OnEdgesChange;
+  /** Removes edges from our store*/
+  removeEdgesByTarget: (nodeIds: string[]) => void;
 }
 
 export interface DagEdgeSlice extends DagEdgeSliceState, DagEdgeSliceActions {}
@@ -26,6 +28,15 @@ export const createDagEdgeSlice: StateCreator<
       },
       false,
       'onEdgesChange'
+    );
+  },
+  removeEdgesByTarget: (nodeIds: string[]) => {
+    set(
+      {
+        dagEdges: get().dagEdges.filter((edge) => !nodeIds.includes(edge.target)),
+      },
+      false,
+      'removeEdgesByTarget'
     );
   },
 });

--- a/src/store/DagEdgeSlice/dagEdgeSlice.ts
+++ b/src/store/DagEdgeSlice/dagEdgeSlice.ts
@@ -1,4 +1,5 @@
 import { applyEdgeChanges, Edge, EdgeChange, OnEdgesChange } from 'reactflow';
+import { addDagEdge } from 'store/DagEdgeSlice/dagEdgeUtils';
 import { StateCreator } from 'zustand';
 
 interface DagEdgeSliceState {
@@ -10,6 +11,8 @@ interface DagEdgeSliceActions {
   onEdgesChange: OnEdgesChange;
   /** Removes edges from our store*/
   removeEdgesByTarget: (nodeIds: string[]) => void;
+  /** Create an edge */
+  createEdge: (sourceId?: string, targetId?: string) => void;
 }
 
 export interface DagEdgeSlice extends DagEdgeSliceState, DagEdgeSliceActions {}
@@ -37,6 +40,17 @@ export const createDagEdgeSlice: StateCreator<
       },
       false,
       'removeEdgesByTarget'
+    );
+  },
+  createEdge: (sourceId?: string, targetId?: string) => {
+    if (!sourceId || !targetId) return undefined;
+    const newEdges = addDagEdge(get().dagEdges, { source: sourceId, target: targetId });
+    set(
+      {
+        dagEdges: newEdges,
+      },
+      false,
+      'createEdge'
     );
   },
 });

--- a/src/store/DagEdgeSlice/dagEdgeUtils.spec.ts
+++ b/src/store/DagEdgeSlice/dagEdgeUtils.spec.ts
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import { Edge } from 'reactflow';
+import { addDagEdge, createDagEdge } from 'store/DagEdgeSlice/dagEdgeUtils';
+import { describe, expect, it, test } from 'vitest';
+
+describe('Dag Edge Slice internals', () => {
+  describe('Create Dag Edge', () => {
+    test('takes 2 Id and returns an edge', () => {
+      const sourceId = '2';
+      const targetId = '3';
+      const edge = createDagEdge(sourceId, targetId);
+      expect(typeof edge).toBe('object');
+      expect(edge.source).toBe(sourceId);
+      expect(edge.target).toBe(targetId);
+    });
+  });
+  it('adding an edge is idempotent', () => {
+    const id1 = '1';
+    const id2 = '2';
+    const id3 = '3';
+    const currentEdges: Edge[] = [{ ...createDagEdge(id1, id2) }, { ...createDagEdge(id2, id3) }];
+    const nonUpdatedEdges = addDagEdge(currentEdges, { source: id1, target: id2 });
+    expect(nonUpdatedEdges).toEqual(currentEdges);
+    const updatedEdges = addDagEdge(currentEdges, { source: id1, target: id3 });
+    expect(updatedEdges.length).toBe(currentEdges.length + 1);
+  });
+});

--- a/src/store/DagEdgeSlice/dagEdgeUtils.spec.ts
+++ b/src/store/DagEdgeSlice/dagEdgeUtils.spec.ts
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 import { Edge } from 'reactflow';
 import { addDagEdge, createDagEdge } from 'store/DagEdgeSlice/dagEdgeUtils';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, suite, test } from 'vitest';
 
-describe('Dag Edge Slice internals', () => {
+suite('Dag Edge Slice internals', () => {
   describe('Create Dag Edge', () => {
     test('takes 2 Id and returns an edge', () => {
       const sourceId = '2';
@@ -14,14 +14,16 @@ describe('Dag Edge Slice internals', () => {
       expect(edge.target).toBe(targetId);
     });
   });
-  it('adding an edge is idempotent', () => {
-    const id1 = '1';
-    const id2 = '2';
-    const id3 = '3';
-    const currentEdges: Edge[] = [{ ...createDagEdge(id1, id2) }, { ...createDagEdge(id2, id3) }];
-    const nonUpdatedEdges = addDagEdge(currentEdges, { source: id1, target: id2 });
-    expect(nonUpdatedEdges).toEqual(currentEdges);
-    const updatedEdges = addDagEdge(currentEdges, { source: id1, target: id3 });
-    expect(updatedEdges.length).toBe(currentEdges.length + 1);
+  describe('Add Dag Edge', () => {
+    test('adding an edge is idempotent', () => {
+      const id1 = '1';
+      const id2 = '2';
+      const id3 = '3';
+      const currentEdges: Edge[] = [{ ...createDagEdge(id1, id2) }, { ...createDagEdge(id2, id3) }];
+      const nonUpdatedEdges = addDagEdge(currentEdges, { source: id1, target: id2 });
+      expect(nonUpdatedEdges).toEqual(currentEdges);
+      const updatedEdges = addDagEdge(currentEdges, { source: id1, target: id3 });
+      expect(updatedEdges.length).toBe(currentEdges.length + 1);
+    });
   });
 });

--- a/src/store/DagEdgeSlice/dagEdgeUtils.ts
+++ b/src/store/DagEdgeSlice/dagEdgeUtils.ts
@@ -1,0 +1,26 @@
+import { Edge, MarkerType } from 'reactflow';
+
+export interface DagEdgeConfig {
+  source: string;
+  target: string;
+}
+
+/** idempotent action to add an edge */
+export const addDagEdge = (currentEdges: Edge[], config: DagEdgeConfig) => {
+  if (currentEdges.find((e) => e.source === config.source && e.target === config.target)) {
+    return currentEdges;
+  }
+  return [...currentEdges, createDagEdge(config.source, config.target)];
+};
+
+/** creates the edges between two nodes with defaults applied */
+export const createDagEdge = (source: string, target: string): Edge => {
+  return {
+    id: `${source}-${target}`,
+    hidden: false,
+    source,
+    target,
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed },
+  };
+};

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -38,7 +38,7 @@ interface DagNodeSliceActions {
   /** Hide a node and all of its descendants*/
   removeDagNodes: (nodeId: string[]) => void;
   /** Set the layout direction */
-  setDagNodePositions: (tree: DecisionTree) => void;
+  positionDagNodes: (tree: DecisionTree) => void;
   /** Used to apply update to existing nodes - used by the react-flow library*/
   onNodesChange: OnNodesChange;
 }
@@ -62,14 +62,14 @@ export const createDagNodeSlice: StateCreator<
       'onNodesChange'
     );
   },
-  setDagNodePositions: (tree: DecisionTree) => {
+  positionDagNodes: (tree: DecisionTree) => {
     const dagNodes = applyPositionToNodes(tree, get().dagNodes);
     set(
       {
         dagNodes,
       },
       false,
-      'setNodeLayout'
+      'positionDagNodes'
     );
   },
   createDagNode: (nodeId: string, tree: DecisionTree) => {
@@ -90,7 +90,7 @@ export const createDagNodeSlice: StateCreator<
         dagNodes: newNodes,
       },
       false,
-      'removeDagNode'
+      'removeNode'
     );
   },
 });

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -26,14 +26,11 @@ export interface ShowDagNodeOptions {
 
 interface DagNodeSliceState {
   dagNodes: DagNode[];
-  // dagEdges: Edge[];
 }
 
 interface DagNodeSliceActions {
-  /** Show the direct children of a node in the tree */
-  createChildrenNodes: (nodeId: string, tree: DecisionTree) => void;
   /** Show a node in the tree - Currently does not create edges*/
-  createDagNode: (nodeId: string, tree: DecisionTree, options?: ShowDagNodeOptions) => void;
+  createDagNode: (nodeId: string, tree: DecisionTree) => void;
   /** Hide a node and all of its descendants*/
   removeDagNodes: (nodeId: string[]) => void;
   /** Set the layout direction */
@@ -71,8 +68,6 @@ export const createDagNodeSlice: StateCreator<
       'setNodeLayout'
     );
   },
-
-  /** ToDo: remove options. can be done after when we create EdgeSlice*/
   createDagNode: (nodeId: string, tree: DecisionTree) => {
     const dagNodes = filterNodes(get().dagNodes, [nodeId]);
     const newNode = createDagNode(nodeId, tree[nodeId]);
@@ -96,34 +91,7 @@ export const createDagNodeSlice: StateCreator<
       'removeDagNode'
     );
   },
-  /** ToDo: move logic into TreeSlice and consolidate with createDagNode */
-  createChildrenNodes: (nodeId: string, tree: DecisionTree) => {
-    const childrenData = getTreeChildren(tree, tree[nodeId]);
-    // const newEdges = createChildrenEdges(nodeId, childrenData);
-    const newNodes = createChildrenNodes(childrenData);
-    childrenData.forEach((childNode) => (tree[childNode.id].hidden = false));
-    set(
-      {
-        dagNodes: [...get().dagNodes, ...newNodes],
-        // dagEdges: [...get().dagEdges, ...newEdges],
-      },
-      false,
-      'showNewChildren'
-    );
-  },
 });
-
-const getTreeChildren = (tree: DecisionTree, treeNode: TreeNode): DagNode[] => {
-  return treeNode.data.children.map((childId) => ({
-    ...tree[childId],
-  }));
-};
-
-const createChildrenNodes = (children: TreeNode[]): DagNode[] => {
-  return children.map((treeNode) => {
-    return createDagNode(treeNode.id, { ...treeNode, hidden: false });
-  });
-};
 
 const filterNodes = (nodes: DagNode[], ids: string[]): DagNode[] => {
   return nodes.filter((node) => !ids.includes(node.id));

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -53,6 +53,7 @@ export const createDagNodeSlice: StateCreator<
 > = (set, get) => ({
   dagEdges: [],
   dagNodes: [],
+  /* v8 ignore next 9  - this is something needed by the React flow library, not tested by us*/
   onNodesChange: (changes: NodeChange[]) => {
     set(
       {

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -1,6 +1,10 @@
 import { BooleanNodeData, NodeData } from 'hooks/useFetchConfig/useFetchConfig';
 import { applyNodeChanges, Node, NodeChange, OnNodesChange } from 'reactflow';
-import { applyPositionToNodes, createDagNode } from 'store/DagNodeSlice/dagNodeUtils';
+import {
+  applyPositionToNodes,
+  createDagNode,
+  filterNodesById,
+} from 'store/DagNodeSlice/dagNodeUtils';
 import { StateCreator } from 'zustand';
 
 /** A vertex in our decision tree.*/
@@ -69,7 +73,7 @@ export const createDagNodeSlice: StateCreator<
     );
   },
   createDagNode: (nodeId: string, tree: DecisionTree) => {
-    const dagNodes = filterNodes(get().dagNodes, [nodeId]);
+    const dagNodes = filterNodesById(get().dagNodes, [nodeId]);
     const newNode = createDagNode(nodeId, tree[nodeId]);
     set(
       {
@@ -80,19 +84,13 @@ export const createDagNodeSlice: StateCreator<
     );
   },
   removeDagNodes: (nodeId: string[]) => {
-    const newNodes = filterNodes(get().dagNodes, nodeId);
-    // const newEdges = get().dagEdges.filter((edge) => !nodeId.includes(edge.target));
+    const newNodes = filterNodesById(get().dagNodes, nodeId);
     set(
       {
         dagNodes: newNodes,
-        // dagEdges: newEdges,
       },
       false,
       'removeDagNode'
     );
   },
 });
-
-const filterNodes = (nodes: DagNode[], ids: string[]): DagNode[] => {
-  return nodes.filter((node) => !ids.includes(node.id));
-};

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -1,11 +1,6 @@
 import { BooleanNodeData, NodeData } from 'hooks/useFetchConfig/useFetchConfig';
-import { applyNodeChanges, Edge, Node, NodeChange, OnNodesChange } from 'reactflow';
-import {
-  addDagEdge,
-  applyPositionToNodes,
-  createDagEdge,
-  createDagNode,
-} from 'store/DagNodeSlice/dagNodeUtils';
+import { applyNodeChanges, Node, NodeChange, OnNodesChange } from 'reactflow';
+import { applyPositionToNodes, createDagNode } from 'store/DagNodeSlice/dagNodeUtils';
 import { StateCreator } from 'zustand';
 
 /** A vertex in our decision tree.*/
@@ -78,19 +73,12 @@ export const createDagNodeSlice: StateCreator<
   },
 
   /** ToDo: remove options. can be done after when we create EdgeSlice*/
-  createDagNode: (nodeId: string, tree: DecisionTree, options?: ShowDagNodeOptions) => {
-    const dagEdges = options?.parentId
-      ? addDagEdge(get().dagEdges, {
-          source: options.parentId,
-          target: nodeId,
-        })
-      : get().dagEdges;
+  createDagNode: (nodeId: string, tree: DecisionTree) => {
     const dagNodes = filterNodes(get().dagNodes, [nodeId]);
     const newNode = createDagNode(nodeId, tree[nodeId]);
     set(
       {
         dagNodes: [...dagNodes, newNode],
-        dagEdges,
       },
       false,
       'createNode'
@@ -111,13 +99,13 @@ export const createDagNodeSlice: StateCreator<
   /** ToDo: move logic into TreeSlice and consolidate with createDagNode */
   createChildrenNodes: (nodeId: string, tree: DecisionTree) => {
     const childrenData = getTreeChildren(tree, tree[nodeId]);
-    const newEdges = createChildrenEdges(nodeId, childrenData);
+    // const newEdges = createChildrenEdges(nodeId, childrenData);
     const newNodes = createChildrenNodes(childrenData);
     childrenData.forEach((childNode) => (tree[childNode.id].hidden = false));
     set(
       {
         dagNodes: [...get().dagNodes, ...newNodes],
-        dagEdges: [...get().dagEdges, ...newEdges],
+        // dagEdges: [...get().dagEdges, ...newEdges],
       },
       false,
       'showNewChildren'
@@ -129,10 +117,6 @@ const getTreeChildren = (tree: DecisionTree, treeNode: TreeNode): DagNode[] => {
   return treeNode.data.children.map((childId) => ({
     ...tree[childId],
   }));
-};
-
-const createChildrenEdges = (parentId: string, children: TreeNode[]): Edge[] => {
-  return children.map((child) => createDagEdge(parentId, child.id));
 };
 
 const createChildrenNodes = (children: TreeNode[]): DagNode[] => {

--- a/src/store/DagNodeSlice/dagNodeSlice.ts
+++ b/src/store/DagNodeSlice/dagNodeSlice.ts
@@ -1,14 +1,5 @@
 import { BooleanNodeData, NodeData } from 'hooks/useFetchConfig/useFetchConfig';
-import {
-  applyEdgeChanges,
-  applyNodeChanges,
-  Edge,
-  EdgeChange,
-  Node,
-  NodeChange,
-  OnEdgesChange,
-  OnNodesChange,
-} from 'reactflow';
+import { applyNodeChanges, Edge, Node, NodeChange, OnNodesChange } from 'reactflow';
 import {
   addDagEdge,
   applyPositionToNodes,
@@ -40,7 +31,7 @@ export interface ShowDagNodeOptions {
 
 interface DagNodeSliceState {
   dagNodes: DagNode[];
-  dagEdges: Edge[];
+  // dagEdges: Edge[];
 }
 
 interface DagNodeSliceActions {
@@ -54,8 +45,6 @@ interface DagNodeSliceActions {
   setDagNodePositions: (tree: DecisionTree) => void;
   /** Used to apply update to existing nodes - used by the react-flow library*/
   onNodesChange: OnNodesChange;
-  /** Used to apply update to existing edges - used by the react-flow library*/
-  onEdgesChange: OnEdgesChange;
 }
 
 export interface DagNodeSlice extends DagNodeSliceState, DagNodeSliceActions {}
@@ -75,15 +64,6 @@ export const createDagNodeSlice: StateCreator<
       },
       false,
       'onNodesChange'
-    );
-  },
-  onEdgesChange: (changes: EdgeChange[]) => {
-    set(
-      {
-        dagEdges: applyEdgeChanges(changes, get().dagEdges),
-      },
-      false,
-      'onEdgesChange'
     );
   },
   setDagNodePositions: (tree: DecisionTree) => {
@@ -118,11 +98,11 @@ export const createDagNodeSlice: StateCreator<
   },
   removeDagNodes: (nodeId: string[]) => {
     const newNodes = filterNodes(get().dagNodes, nodeId);
-    const newEdges = get().dagEdges.filter((edge) => !nodeId.includes(edge.target));
+    // const newEdges = get().dagEdges.filter((edge) => !nodeId.includes(edge.target));
     set(
       {
         dagNodes: newNodes,
-        dagEdges: newEdges,
+        // dagEdges: newEdges,
       },
       false,
       'removeDagNode'

--- a/src/store/DagNodeSlice/dagNodeUtils.spec.ts
+++ b/src/store/DagNodeSlice/dagNodeUtils.spec.ts
@@ -1,11 +1,11 @@
 import '@testing-library/jest-dom';
 import { DagNode, DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
 import { applyPositionToNodes, filterNodesById } from 'store/DagNodeSlice/dagNodeUtils';
-import { describe, expect, it, suite, test } from 'vitest';
+import { describe, expect, suite, test } from 'vitest';
 
 suite('Dag Node Slice internals', () => {
   describe('applyPositionToNodes', () => {
-    it('Applies tree positions to nodes', () => {
+    test('Applies tree positions to nodes', () => {
       const oldX = 0;
       const oldY = 10;
       const newX = 100;

--- a/src/store/DagNodeSlice/dagNodeUtils.spec.ts
+++ b/src/store/DagNodeSlice/dagNodeUtils.spec.ts
@@ -1,43 +1,83 @@
 import '@testing-library/jest-dom';
-import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { applyPositionToNodes } from 'store/DagNodeSlice/dagNodeUtils';
-import { describe, expect, it } from 'vitest';
+import { DagNode, DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
+import { applyPositionToNodes, filterNodesById } from 'store/DagNodeSlice/dagNodeUtils';
+import { describe, expect, it, suite, test } from 'vitest';
 
-describe('Dag Node Slice internals', () => {
-  it('Applies tree positions to nodes', () => {
-    const oldX = 0;
-    const oldY = 10;
-    const newX = 100;
-    const newY = 156;
-    const tree: DecisionTree = {
-      ['1']: {
-        id: '1',
-        data: {
-          label: 'this is a question?',
-          yesId: '2',
-          noId: '3',
-          children: [],
+suite('Dag Node Slice internals', () => {
+  describe('applyPositionToNodes', () => {
+    it('Applies tree positions to nodes', () => {
+      const oldX = 0;
+      const oldY = 10;
+      const newX = 100;
+      const newY = 156;
+      const tree: DecisionTree = {
+        ['1']: {
+          id: '1',
+          data: {
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+          },
+          position: { x: newX, y: newY, rank: 0 },
+          type: 'BoolNode',
+          hidden: false,
         },
-        position: { x: newX, y: newY, rank: 0 },
-        type: 'BoolNode',
-        hidden: false,
-      },
-    };
-    const existingNodes = [
-      {
-        id: '1',
-        data: {
-          label: 'this is a question?',
-          yesId: '2',
-          noId: '3',
-          children: [],
+      };
+      const existingNodes = [
+        {
+          id: '1',
+          data: {
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+          },
+          position: { x: oldX, y: oldY },
+          type: 'BoolNode',
+          hidden: false,
         },
-        position: { x: oldX, y: oldY },
-        type: 'BoolNode',
-        hidden: false,
-      },
-    ];
-    const nodesWithPositions = applyPositionToNodes(tree, existingNodes);
-    expect(nodesWithPositions[0].position).toEqual({ x: newX, y: newY });
+      ];
+      const nodesWithPositions = applyPositionToNodes(tree, existingNodes);
+      expect(nodesWithPositions[0].position).toEqual({ x: newX, y: newY });
+    });
+  });
+  describe('filterNodesById', () => {
+    test('returns an array', () => {
+      const nodeId = '1';
+      const nodes: DagNode[] = [
+        {
+          id: nodeId,
+          data: {
+            label: 'this is a question?',
+          },
+          position: { x: 0, y: 10 },
+        },
+      ];
+      const filteredNodes = filterNodesById(nodes, [nodeId]);
+      expect(filteredNodes).toBeInstanceOf(Array);
+    });
+    test('filters nodes with the given ID', () => {
+      const nodeId = '1';
+      const nodes: DagNode[] = [
+        {
+          id: nodeId,
+          data: {
+            label: 'this is a question?',
+          },
+          position: { x: 0, y: 10 },
+        },
+        {
+          id: '2',
+          data: {
+            label: 'this is a question?',
+          },
+          position: { x: 0, y: 10 },
+        },
+      ];
+      const filteredNodes = filterNodesById(nodes, [nodeId]);
+      expect(filteredNodes.length).toBe(nodes.length - 1);
+      expect(filteredNodes.map((node) => node.id)).not.toContain(nodeId);
+    });
   });
 });

--- a/src/store/DagNodeSlice/dagNodeUtils.spec.ts
+++ b/src/store/DagNodeSlice/dagNodeUtils.spec.ts
@@ -1,20 +1,9 @@
 import '@testing-library/jest-dom';
-import { Edge } from 'reactflow';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { addDagEdge, applyPositionToNodes, createDagEdge } from 'store/DagNodeSlice/dagNodeUtils';
-import { describe, expect, it, test } from 'vitest';
+import { applyPositionToNodes } from 'store/DagNodeSlice/dagNodeUtils';
+import { describe, expect, it } from 'vitest';
 
-describe('Dag Slice internals', () => {
-  describe('Create Dag Edge', () => {
-    test('takes 2 Id and returns an edge', () => {
-      const sourceId = '2';
-      const targetId = '3';
-      const edge = createDagEdge(sourceId, targetId);
-      expect(typeof edge).toBe('object');
-      expect(edge.source).toBe(sourceId);
-      expect(edge.target).toBe(targetId);
-    });
-  });
+describe('Dag Node Slice internals', () => {
   it('Applies tree positions to nodes', () => {
     const oldX = 0;
     const oldY = 10;
@@ -50,15 +39,5 @@ describe('Dag Slice internals', () => {
     ];
     const nodesWithPositions = applyPositionToNodes(tree, existingNodes);
     expect(nodesWithPositions[0].position).toEqual({ x: newX, y: newY });
-  });
-  it('adding an edge is idempotent', () => {
-    const id1 = '1';
-    const id2 = '2';
-    const id3 = '3';
-    const currentEdges: Edge[] = [{ ...createDagEdge(id1, id2) }, { ...createDagEdge(id2, id3) }];
-    const nonUpdatedEdges = addDagEdge(currentEdges, { source: id1, target: id2 });
-    expect(nonUpdatedEdges).toEqual(currentEdges);
-    const updatedEdges = addDagEdge(currentEdges, { source: id1, target: id3 });
-    expect(updatedEdges.length).toBe(currentEdges.length + 1);
   });
 });

--- a/src/store/DagNodeSlice/dagNodeUtils.ts
+++ b/src/store/DagNodeSlice/dagNodeUtils.ts
@@ -3,33 +3,7 @@
  * this will help maintain testability and make it easier to refactor later
  *  Do not export outside this module
  * */
-import { Edge, MarkerType } from 'reactflow';
 import { DagNode, DecisionTree, TreeNode } from 'store/DagNodeSlice/dagNodeSlice';
-
-export interface DagEdgeConfig {
-  source: string;
-  target: string;
-}
-
-/** idempotent action to add an edge */
-export const addDagEdge = (currentEdges: Edge[], config: DagEdgeConfig) => {
-  if (currentEdges.find((e) => e.source === config.source && e.target === config.target)) {
-    return currentEdges;
-  }
-  return [...currentEdges, createDagEdge(config.source, config.target)];
-};
-
-/** creates the edges between two nodes with defaults applied */
-export const createDagEdge = (source: string, target: string): Edge => {
-  return {
-    id: `${source}-${target}`,
-    hidden: false,
-    source,
-    target,
-    type: 'smoothstep',
-    markerEnd: { type: MarkerType.ArrowClosed },
-  };
-};
 
 /** create a new position unaware node with defaults applied */
 export const createDagNode = (id: string, config: Partial<TreeNode>): DagNode => {

--- a/src/store/DagNodeSlice/dagNodeUtils.ts
+++ b/src/store/DagNodeSlice/dagNodeUtils.ts
@@ -34,3 +34,8 @@ export const applyPositionToNodes = (tree: DecisionTree, nodes: DagNode[]) => {
     return newNode;
   });
 };
+
+/** Filter nodes by id */
+export const filterNodesById = (nodes: DagNode[], ids: string[]): DagNode[] => {
+  return nodes.filter((node) => !ids.includes(node.id));
+};

--- a/src/store/DecisionSlice/decisionSlice.ts
+++ b/src/store/DecisionSlice/decisionSlice.ts
@@ -1,5 +1,11 @@
 import { BooleanNodeData, NodeData } from 'hooks/useFetchConfig/useFetchConfig';
 import { Node } from 'reactflow';
+import {
+  setCollapsed,
+  setExpanded,
+  setNodesHidden,
+  setNodeVisible,
+} from 'store/DecisionSlice/decisionUtils';
 import { layoutTree } from 'store/DecisionSlice/layout';
 import { StateCreator } from 'zustand';
 
@@ -30,13 +36,13 @@ interface DecisionSliceActions {
   /** Set the layout direction */
   setTreeDirection: (direction: TreeDirection) => void;
   /** Set vertex as visible */
-  setDecisionVisible: (nodeId: string) => void;
+  showDecision: (nodeId: string) => void;
   /** Set decision as hidden */
-  setDecisionHidden: (nodeId: string) => void;
+  hideDecision: (nodeId: string) => void;
   /** set the node as expended */
-  setDecisionExpanded: (nodeId: string) => void;
+  expandDecision: (nodeId: string) => void;
   /** Set decision as collapsed */
-  setDecisionCollapsed: (nodeId: string, children: string[]) => void;
+  collapseDecision: (nodeId: string, children: string[]) => void;
 }
 
 export interface DecisionSlice extends DecisionSliceActions, DecisionSliceState {}
@@ -70,8 +76,8 @@ export const createDecisionSlice: StateCreator<
       'setNewTree'
     );
   },
-  setDecisionVisible: (nodeId: string) => {
-    const tree = setNodeVisible(get().tree, nodeId);
+  showDecision: (nodeId: string) => {
+    const tree = setNodeVisible(get().tree, [nodeId]);
     set(
       {
         tree,
@@ -80,7 +86,7 @@ export const createDecisionSlice: StateCreator<
       'showVertex'
     );
   },
-  setDecisionHidden: (nodeId: string) => {
+  hideDecision: (nodeId: string) => {
     const tree = setNodesHidden(get().tree, [nodeId]);
     set(
       {
@@ -90,7 +96,7 @@ export const createDecisionSlice: StateCreator<
       'hideDecision'
     );
   },
-  setDecisionExpanded: (nodeId: string) => {
+  expandDecision: (nodeId: string) => {
     const tree = setExpanded(get().tree, [nodeId]);
     set(
       {
@@ -100,7 +106,7 @@ export const createDecisionSlice: StateCreator<
       'expandDecision'
     );
   },
-  setDecisionCollapsed: (nodeId: string, children: string[]) => {
+  collapseDecision: (nodeId: string, children: string[]) => {
     const tree = get().tree;
     const hiddenTree = setNodesHidden(tree, children);
     const collapsedTree = setCollapsed(hiddenTree, [...children, nodeId]);
@@ -113,23 +119,3 @@ export const createDecisionSlice: StateCreator<
     );
   },
 });
-
-const setNodeVisible = (tree: DecisionTree, nodeId: string) => {
-  tree[nodeId].hidden = false;
-  return tree;
-};
-
-const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
-  nodeIds.forEach((id) => (tree[id].hidden = true));
-  return tree;
-};
-
-const setExpanded = (tree: DecisionTree, nodeIds: string[]) => {
-  nodeIds.forEach((id) => (tree[id].data.expanded = true));
-  return tree;
-};
-
-const setCollapsed = (tree: DecisionTree, nodeIds: string[]) => {
-  nodeIds.forEach((id) => (tree[id].data.expanded = false));
-  return tree;
-};

--- a/src/store/DecisionSlice/decisionUtils.spec.ts
+++ b/src/store/DecisionSlice/decisionUtils.spec.ts
@@ -1,8 +1,6 @@
 import '@testing-library/jest-dom';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
 import {
-  getDescendantIds,
-  getSiblingIds,
   setCollapsed,
   setExpanded,
   setNodesHidden,
@@ -11,57 +9,6 @@ import {
 import { describe, expect, suite, test } from 'vitest';
 
 suite('Tree Slice internals', () => {
-  describe('Get Descendants ID', () => {
-    test('returns an array', () => {
-      const ids = getDescendantIds({}, '1');
-      expect(ids).toBeInstanceOf(Array);
-    });
-  });
-  describe('Get Siblings IDs', () => {
-    test('Find all sibling node IDs', () => {
-      const rootId = '1';
-      const siblingId2 = '2';
-      const siblingId3 = '3';
-      const siblingId4 = '4';
-      const tree: DecisionTree = {
-        [rootId]: {
-          id: '1',
-          data: {
-            children: [siblingId2, siblingId3, siblingId4],
-            label: 'Root',
-          },
-          position: { x: 0, y: 0, rank: 0 },
-        },
-        [siblingId2]: {
-          id: '2',
-          data: {
-            children: [],
-            label: 'Sibling 2',
-          },
-          position: { x: 0, y: 0, rank: 2 },
-        },
-        [siblingId3]: {
-          id: '3',
-          data: {
-            children: [],
-            label: 'Sibling 3',
-          },
-          position: { x: 0, y: 0, rank: 2 },
-        },
-        [siblingId4]: {
-          id: '4',
-          data: {
-            children: [],
-            label: 'Sibling 4',
-          },
-          position: { x: 0, y: 0, rank: 2 },
-        },
-      };
-      expect(getSiblingIds(tree, siblingId2)).toEqual([siblingId3, siblingId4]);
-      expect(getSiblingIds(tree, siblingId3)).toEqual([siblingId2, siblingId4]);
-      expect(getSiblingIds(tree, siblingId4)).toEqual([siblingId2, siblingId3]);
-    });
-  });
   describe('Set Node Visible', () => {
     test('Set hidden to false (idempotent)', () => {
       const tree: DecisionTree = {

--- a/src/store/DecisionSlice/decisionUtils.spec.ts
+++ b/src/store/DecisionSlice/decisionUtils.spec.ts
@@ -1,6 +1,13 @@
 import '@testing-library/jest-dom';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { getDescendantIds, getSiblingIds } from 'store/DecisionSlice/decisionUtils';
+import {
+  getDescendantIds,
+  getSiblingIds,
+  setCollapsed,
+  setExpanded,
+  setNodesHidden,
+  setNodeVisible,
+} from 'store/DecisionSlice/decisionUtils';
 import { describe, expect, suite, test } from 'vitest';
 
 suite('Tree Slice internals', () => {
@@ -54,6 +61,53 @@ suite('Tree Slice internals', () => {
       expect(getSiblingIds(tree, siblingId3)).toEqual([siblingId2, siblingId4]);
       expect(getSiblingIds(tree, siblingId4)).toEqual([siblingId2, siblingId3]);
     });
-    describe('');
+  });
+  describe('Set Node Visible', () => {
+    test('Set hidden to false (idempotent)', () => {
+      const tree: DecisionTree = {
+        // @ts-expect-error - use a minimal tree for testing
+        '1': { id: '1', hidden: true, data: { label: 'foo' } },
+      };
+      const updatedTree = setNodeVisible(tree, ['1']);
+      expect(updatedTree['1'].hidden).toBe(false);
+      const idempotentTree = setNodeVisible(updatedTree, ['1']);
+      expect(idempotentTree['1'].hidden).toBe(false);
+    });
+  });
+  describe('Set Node Hidden', () => {
+    test('Set hidden to true (idempotent)', () => {
+      const tree: DecisionTree = {
+        // @ts-expect-error - use a minimal tree for testing
+        '1': { id: '1', hidden: false, data: { label: 'foo' } },
+      };
+      const updatedTree = setNodesHidden(tree, ['1']);
+      expect(updatedTree['1'].hidden).toBe(true);
+      const idempotentTree = setNodesHidden(updatedTree, ['1']);
+      expect(idempotentTree['1'].hidden).toBe(true);
+    });
+  });
+  describe('Set Node Expanded', () => {
+    test('Set expanded to true (idempotent)', () => {
+      const tree: DecisionTree = {
+        // @ts-expect-error - use a minimal tree for testing
+        '1': { id: '1', hidden: false, data: { label: 'foo', expanded: false } },
+      };
+      const updatedTree = setExpanded(tree, ['1']);
+      expect(updatedTree['1'].data.expanded).toBe(true);
+      const idempotentTree = setExpanded(updatedTree, ['1']);
+      expect(idempotentTree['1'].data.expanded).toBe(true);
+    });
+  });
+  describe('Set Node Collapsed', () => {
+    test('Set expanded to false (idempotent)', () => {
+      const tree: DecisionTree = {
+        // @ts-expect-error - use a minimal tree for testing
+        '1': { id: '1', hidden: false, data: { label: 'foo', expanded: true } },
+      };
+      const updatedTree = setCollapsed(tree, ['1']);
+      expect(updatedTree['1'].data.expanded).toBe(false);
+      const idempotentTree = setCollapsed(updatedTree, ['1']);
+      expect(idempotentTree['1'].data.expanded).toBe(false);
+    });
   });
 });

--- a/src/store/DecisionSlice/decisionUtils.spec.ts
+++ b/src/store/DecisionSlice/decisionUtils.spec.ts
@@ -1,14 +1,9 @@
 import '@testing-library/jest-dom';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
 import { getDescendantIds, getSiblingIds } from 'store/DecisionSlice/decisionUtils';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, suite, test } from 'vitest';
 
-describe('Tree Slice internals', () => {
-  describe('Temporary scaffolding', () => {
-    test('Temporary scaffolding', () => {
-      expect(true).toBeTruthy();
-    });
-  });
+suite('Tree Slice internals', () => {
   describe('Get Descendants ID', () => {
     test('returns an array', () => {
       const ids = getDescendantIds({}, '1');
@@ -59,5 +54,6 @@ describe('Tree Slice internals', () => {
       expect(getSiblingIds(tree, siblingId3)).toEqual([siblingId2, siblingId4]);
       expect(getSiblingIds(tree, siblingId4)).toEqual([siblingId2, siblingId3]);
     });
+    describe('');
   });
 });

--- a/src/store/DecisionSlice/decisionUtils.ts
+++ b/src/store/DecisionSlice/decisionUtils.ts
@@ -28,16 +28,19 @@ export const setNodeVisible = (tree: DecisionTree, nodeIds: string[]) => {
   return tree;
 };
 
+/** set hidden to true */
 export const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
   nodeIds.forEach((id) => (tree[id].hidden = true));
   return tree;
 };
 
+/** set expanded to true */
 export const setExpanded = (tree: DecisionTree, nodeIds: string[]) => {
   nodeIds.forEach((id) => (tree[id].data.expanded = true));
   return tree;
 };
 
+/** set expanded to false */
 export const setCollapsed = (tree: DecisionTree, nodeIds: string[]) => {
   nodeIds.forEach((id) => (tree[id].data.expanded = false));
   return tree;

--- a/src/store/DecisionSlice/decisionUtils.ts
+++ b/src/store/DecisionSlice/decisionUtils.ts
@@ -22,3 +22,23 @@ export const getSiblingIds = (tree: DecisionTree, id: string): string[] => {
     .filter((n) => n.position.rank === rank && n.id !== id)
     .map((n) => n.id);
 };
+/** set hidden to false */
+export const setNodeVisible = (tree: DecisionTree, nodeIds: string[]) => {
+  nodeIds.forEach((id) => (tree[id].hidden = false));
+  return tree;
+};
+
+export const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
+  nodeIds.forEach((id) => (tree[id].hidden = true));
+  return tree;
+};
+
+export const setExpanded = (tree: DecisionTree, nodeIds: string[]) => {
+  nodeIds.forEach((id) => (tree[id].data.expanded = true));
+  return tree;
+};
+
+export const setCollapsed = (tree: DecisionTree, nodeIds: string[]) => {
+  nodeIds.forEach((id) => (tree[id].data.expanded = false));
+  return tree;
+};

--- a/src/store/DecisionSlice/decisionUtils.ts
+++ b/src/store/DecisionSlice/decisionUtils.ts
@@ -1,27 +1,5 @@
 import { DecisionTree } from 'store/DecisionSlice/decisionSlice';
 
-/** Accepts a DecisionTree and node ID and returns an array of children IDs of all descendant nodes in the DAG */
-export const getDescendantIds = (tree: DecisionTree, id: string): string[] => {
-  let childrenIds: string[] = [];
-
-  if (tree[id]?.data.children) {
-    tree[id].data.children?.forEach((child) => {
-      childrenIds.push(child);
-      childrenIds = childrenIds.concat(getDescendantIds(tree, child));
-    });
-  }
-
-  return childrenIds;
-};
-/** Accepts a DecisionTree and node ID and returns an array of sibling IDs */
-export const getSiblingIds = (tree: DecisionTree, id: string): string[] => {
-  const node = tree[id];
-  if (node.position.rank === undefined) throw new Error('Node must have a rank to find siblings');
-  const rank = node.position.rank;
-  return Object.values(tree)
-    .filter((n) => n.position.rank === rank && n.id !== id)
-    .map((n) => n.id);
-};
 /** set hidden to false */
 export const setNodeVisible = (tree: DecisionTree, nodeIds: string[]) => {
   nodeIds.forEach((id) => (tree[id].hidden = false));

--- a/src/store/DecisionSlice/layout.spec.ts
+++ b/src/store/DecisionSlice/layout.spec.ts
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
 import { PositionUnawareDecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
 import { layoutTree } from 'store/DecisionSlice/layout';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 describe('DAG layout', () => {
-  it('accepts a position unaware tree and returns position aware tree', () => {
+  test('accepts a position unaware tree and returns position aware tree', () => {
     const nodeId = '2';
     const positionUnawareTree: PositionUnawareDecisionTree = {
       [nodeId]: {
@@ -21,7 +21,7 @@ describe('DAG layout', () => {
     expect(typeof tree).toBe('object');
     expect(tree[nodeId].position).toBeDefined();
   });
-  it('changes rank direction based on optional argument', () => {
+  test('changes rank direction based on optional argument', () => {
     const parentId = '2';
     const childId = '3';
     const positionUnawareTree: PositionUnawareDecisionTree = {

--- a/src/store/DecisionSlice/layout.ts
+++ b/src/store/DecisionSlice/layout.ts
@@ -1,7 +1,7 @@
 import dagre from '@dagrejs/dagre';
 import { Edge } from 'reactflow';
+import { createDagEdge } from 'store/DagEdgeSlice/dagEdgeUtils';
 import { DecisionTree, PositionUnawareDecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { createDagEdge } from 'store/DagNodeSlice/dagNodeUtils';
 import { TreeDirection } from 'store/DecisionSlice/decisionSlice';
 
 const dagreGraph = new dagre.graphlib.Graph<{

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -47,8 +47,14 @@ export const createTreeSlice: StateCreator<
     get().removeDagNodes([nodeId]);
   },
   showChildren: (nodeId: string) => {
+    const childrenIds = get().tree[nodeId].data.children;
+    const tree = get().tree;
+    childrenIds?.forEach((id) => {
+      get().setDecisionVisible(id);
+      get().createDagNode(id, tree);
+      get().createEdge(nodeId, id);
+    });
     get().setDecisionExpanded(nodeId);
-    get().createChildrenNodes(nodeId, get().tree);
   },
   hideDescendants: (nodeId: string) => {
     const childrenIds = getDescendantIds(get().tree, nodeId);

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -38,7 +38,8 @@ export const createTreeSlice: StateCreator<
   showNode: (nodeId: string, options?: ShowDagNodeOptions) => {
     get().setDecisionVisible(nodeId);
     const tree = get().tree;
-    get().createDagNode(nodeId, tree, options);
+    get().createDagNode(nodeId, tree);
+    get().createEdge(options?.parentId, nodeId);
   },
   hideNode: (nodeId: string) => {
     get().setDecisionHidden(nodeId);

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -1,3 +1,4 @@
+import { DagEdgeSlice } from 'store/DagEdgeSlice/dagEdgeSlice';
 import {
   DagNodeSlice,
   PositionUnawareDecisionTree,
@@ -21,10 +22,12 @@ export interface TreeSlice {
 /** The state of the tree, implemented as a shared slice that builds on concrete slices
  * and exposes an interface of actions that can take on the decision tree
  * */
-export const createTreeSlice: StateCreator<DecisionSlice & DagNodeSlice, [], [], TreeSlice> = (
-  _set,
-  get
-) => ({
+export const createTreeSlice: StateCreator<
+  DecisionSlice & DagNodeSlice & DagEdgeSlice,
+  [],
+  [],
+  TreeSlice
+> = (_set, get) => ({
   setDirection: (direction: TreeDirection) => {
     get().setTreeDirection(direction);
     get().setDagNodePositions(get().tree);
@@ -39,6 +42,7 @@ export const createTreeSlice: StateCreator<DecisionSlice & DagNodeSlice, [], [],
   },
   hideNode: (nodeId: string) => {
     get().setDecisionHidden(nodeId);
+    get().removeEdgesByTarget([nodeId]);
     get().removeDagNodes([nodeId]);
   },
   showChildren: (nodeId: string) => {

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -30,19 +30,19 @@ export const createTreeSlice: StateCreator<
 > = (_set, get) => ({
   setDirection: (direction: TreeDirection) => {
     get().setTreeDirection(direction);
-    get().setDagNodePositions(get().tree);
+    get().positionDagNodes(get().tree);
   },
   setTree: (tree: PositionUnawareDecisionTree) => {
     get().setDecisionTree(tree);
   },
   showNode: (nodeId: string, options?: ShowDagNodeOptions) => {
-    get().setDecisionVisible(nodeId);
+    get().showDecision(nodeId);
     const tree = get().tree;
     get().createDagNode(nodeId, tree);
     get().createEdge(options?.parentId, nodeId);
   },
   hideNode: (nodeId: string) => {
-    get().setDecisionHidden(nodeId);
+    get().hideDecision(nodeId);
     get().removeEdgesByTarget([nodeId]);
     get().removeDagNodes([nodeId]);
   },
@@ -50,22 +50,22 @@ export const createTreeSlice: StateCreator<
     const childrenIds = get().tree[nodeId].data.children;
     const tree = get().tree;
     childrenIds?.forEach((id) => {
-      get().setDecisionVisible(id);
+      get().showDecision(id);
       get().createDagNode(id, tree);
       get().createEdge(nodeId, id);
     });
-    get().setDecisionExpanded(nodeId);
+    get().expandDecision(nodeId);
   },
   hideDescendants: (nodeId: string) => {
     const childrenIds = getDescendantIds(get().tree, nodeId);
-    get().setDecisionCollapsed(nodeId, childrenIds);
+    get().collapseDecision(nodeId, childrenIds);
     get().removeDagNodes([...childrenIds]);
   },
   removeNiblings: (nodeId: string) => {
     const dagTree = get().tree;
     const siblingIds = getSiblingIds(dagTree, nodeId);
     const siblingDescendantIds = siblingIds.flatMap((id) => getDescendantIds(dagTree, id));
-    get().setDecisionCollapsed(nodeId, siblingDescendantIds);
+    get().collapseDecision(nodeId, siblingDescendantIds);
     get().removeDagNodes([...siblingDescendantIds]);
   },
 });

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -5,7 +5,7 @@ import {
   ShowDagNodeOptions,
 } from 'store/DagNodeSlice/dagNodeSlice';
 import { DecisionSlice, TreeDirection } from 'store/DecisionSlice/decisionSlice';
-import { getDescendantIds, getSiblingIds } from 'store/DecisionSlice/decisionUtils';
+import { getDescendantIds, getSiblingIds } from 'store/TreeSlice/treeSliceUtils';
 import { StateCreator } from 'zustand';
 
 /** The state and actions of the Combined slice*/

--- a/src/store/TreeSlice/treeSliceUtils.spec.ts
+++ b/src/store/TreeSlice/treeSliceUtils.spec.ts
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
+import { getDescendantIds, getSiblingIds } from 'store/TreeSlice/treeSliceUtils';
+import { describe, expect, suite, test } from 'vitest';
+
+suite('Tree Slice internals', () => {
+  describe('Get Descendants ID', () => {
+    test('returns an array', () => {
+      const ids = getDescendantIds({}, '1');
+      expect(ids).toBeInstanceOf(Array);
+    });
+  });
+  describe('Get Siblings IDs', () => {
+    test('Find all sibling node IDs', () => {
+      const rootId = '1';
+      const siblingId2 = '2';
+      const siblingId3 = '3';
+      const siblingId4 = '4';
+      const tree: DecisionTree = {
+        [rootId]: {
+          id: '1',
+          data: {
+            children: [siblingId2, siblingId3, siblingId4],
+            label: 'Root',
+          },
+          position: { x: 0, y: 0, rank: 0 },
+        },
+        [siblingId2]: {
+          id: '2',
+          data: {
+            children: [],
+            label: 'Sibling 2',
+          },
+          position: { x: 0, y: 0, rank: 2 },
+        },
+        [siblingId3]: {
+          id: '3',
+          data: {
+            children: [],
+            label: 'Sibling 3',
+          },
+          position: { x: 0, y: 0, rank: 2 },
+        },
+        [siblingId4]: {
+          id: '4',
+          data: {
+            children: [],
+            label: 'Sibling 4',
+          },
+          position: { x: 0, y: 0, rank: 2 },
+        },
+      };
+      expect(getSiblingIds(tree, siblingId2)).toEqual([siblingId3, siblingId4]);
+      expect(getSiblingIds(tree, siblingId3)).toEqual([siblingId2, siblingId4]);
+      expect(getSiblingIds(tree, siblingId4)).toEqual([siblingId2, siblingId3]);
+    });
+  });
+});

--- a/src/store/TreeSlice/treeSliceUtils.ts
+++ b/src/store/TreeSlice/treeSliceUtils.ts
@@ -1,0 +1,24 @@
+import { DecisionTree } from 'store/DecisionSlice/decisionSlice';
+
+/** Accepts a DecisionTree and node ID and returns an array of children IDs of all descendant nodes in the DAG */
+export const getDescendantIds = (tree: DecisionTree, id: string): string[] => {
+  let childrenIds: string[] = [];
+
+  if (tree[id]?.data.children) {
+    tree[id].data.children?.forEach((child) => {
+      childrenIds.push(child);
+      childrenIds = childrenIds.concat(getDescendantIds(tree, child));
+    });
+  }
+
+  return childrenIds;
+};
+/** Accepts a DecisionTree and node ID and returns an array of sibling IDs */
+export const getSiblingIds = (tree: DecisionTree, id: string): string[] => {
+  const node = tree[id];
+  if (node.position.rank === undefined) throw new Error('Node must have a rank to find siblings');
+  const rank = node.position.rank;
+  return Object.values(tree)
+    .filter((n) => n.position.rank === rank && n.id !== id)
+    .map((n) => n.id);
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,4 @@
+import { createDagEdgeSlice, DagEdgeSlice } from 'store/DagEdgeSlice/dagEdgeSlice';
 import { createDagNodeSlice, DagNodeSlice } from 'store/DagNodeSlice/dagNodeSlice';
 import { createDecisionSlice, DecisionSlice } from 'store/DecisionSlice/decisionSlice';
 import { createTreeSlice, TreeSlice } from 'store/TreeSlice/treeSlice';
@@ -13,10 +14,11 @@ export type {
 
 export type { TreeDirection, DecisionTree } from 'store/DecisionSlice/decisionSlice';
 
-const useTreeStore = create<DagNodeSlice & DecisionSlice & TreeSlice>()(
+const useTreeStore = create<DagNodeSlice & DecisionSlice & DagEdgeSlice & TreeSlice>()(
   devtools(
     (...args) => ({
       ...createDagNodeSlice(...args),
+      ...createDagEdgeSlice(...args),
       ...createDecisionSlice(...args),
       ...createTreeSlice(...args),
     }),


### PR DESCRIPTION
## Description

Separate the edge slice from our existing slices. With this, our store structure takes shape in a very manageable way. 

we have the followign structure to our Decision Tree store. The Tree store has three sub-slices
1. Node slice. Manages the creation/removal of visible nodes on the tree
2. Edge Slice. Same as above but for edges that connect our nodes
3. Decision Slice. Act as a sort of database that we pull information from to create Nodes and Edges.

There is also a tree slice which is a shared slice (it depends on the above three slices) and unifies the logic, present a clean, abstracted, interface for working with the store. 

for example, the tree slice has a `showNode` action which dispatches actions in the subslices to (1) create a node, (2) create an edge, (3) update our decision slice to reflect the user decisions. 

## Issue ticket number and link

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
