### PR TITLE
Show nearby decisions

### DIFF
--- a/src/components/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.spec.tsx
@@ -94,26 +94,4 @@ describe('BoolNode', () => {
     expect(noButton).toHaveClass(/selected/i);
     expect(yesButton).not.toHaveClass(/selected/i);
   });
-  test('clicking yes/no toggles the visibility of the children nodes', async () => {
-    const user = userEvent.setup();
-    const primaryId = '1';
-    const yesId = '2';
-    const noId = '3';
-
-    render(
-      <TestComponent
-        primaryId={primaryId}
-        yesId={yesId}
-        noId={noId}
-        overwrites={{
-          id: primaryId,
-          data: { label: 'question', yesId: yesId, noId: noId, children: [yesId, noId] },
-        }}
-      />
-    );
-    await user.click(screen.getByRole('button', { name: /yes/i }));
-    expect(useTreeStore.getState().tree[yesId].hidden).toBe(false);
-    await user.click(screen.getByRole('button', { name: /no/i }));
-    expect(useTreeStore.getState().tree[yesId].hidden).toBe(true);
-  });
 });

--- a/src/components/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.tsx
@@ -17,17 +17,19 @@ export const BoolNode = ({
   id,
   ...props
 }: NodeProps<BoolNodeData>) => {
-  const { showNode, hideNode } = useTreeStore();
+  const { showNode, hideNode, showChildren } = useTreeStore();
   const [selected, setSelected] = useState<'yes' | 'no' | undefined>(undefined);
 
   const handleYes = () => {
     showNode(yesId, { parentId: id });
+    showChildren(yesId);
     hideNode(noId);
     setSelected('yes');
   };
 
   const handleNo = () => {
     showNode(noId, { parentId: id });
+    showChildren(noId);
     hideNode(yesId);
     setSelected('no');
   };
@@ -39,10 +41,18 @@ export const BoolNode = ({
           <span>{label}</span>
         </div>
         <div className={styles.boolNodeOptions}>
-          <button onClick={handleYes} className={selected === 'yes' ? styles.selected : ''}>
+          <button
+            onClick={handleYes}
+            className={selected === 'yes' ? styles.selected : ''}
+            data-testid={`${id}-yes-button`}
+          >
             Yes
           </button>
-          <button onClick={handleNo} className={selected === 'no' ? styles.selected : ''}>
+          <button
+            onClick={handleNo}
+            className={selected === 'no' ? styles.selected : ''}
+            data-testid={`${id}-no-button`}
+          >
             No
           </button>
         </div>

--- a/src/components/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Nodes/BoolNode/BoolNode.tsx
@@ -17,20 +17,22 @@ export const BoolNode = ({
   id,
   ...props
 }: NodeProps<BoolNodeData>) => {
-  const { showNode, hideNode, showChildren } = useTreeStore();
+  const { showNode, showChildren, hideNiblings, hideDescendants } = useTreeStore();
   const [selected, setSelected] = useState<'yes' | 'no' | undefined>(undefined);
 
   const handleYes = () => {
     showNode(yesId, { parentId: id });
     showChildren(yesId);
-    hideNode(noId);
+    hideNiblings(id);
+    hideDescendants(noId);
     setSelected('yes');
   };
 
   const handleNo = () => {
     showNode(noId, { parentId: id });
     showChildren(noId);
-    hideNode(yesId);
+    hideNiblings(id);
+    hideDescendants(yesId);
     setSelected('no');
   };
 

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -176,65 +176,6 @@ describe('Tree Component', () => {
     fireEvent.click(screen.queryByTestId(`node-${siblingWithChild2}`)!);
     expect(screen.queryByTestId(`node-${grandchildId}`)).not.toBeInTheDocument();
   });
-  test('hides all descendants of expanded nodes on click', () => {
-    const parentId = '1';
-    const childId = '2';
-    const grandchildId = '3';
-    const greatGrandchildId = '4';
-    const tree: DecisionTree = {
-      [parentId]: {
-        id: parentId,
-        data: {
-          label: 'this is a question?',
-          children: ['2'],
-          expanded: true,
-        },
-        position: { x: 0, y: 0 },
-        type: 'default',
-        hidden: false,
-      },
-      [childId]: {
-        id: childId,
-        data: {
-          label: 'this is an answer?',
-          children: ['3'],
-          expanded: true,
-        },
-        position: { x: 0, y: 0 },
-        type: 'default',
-        hidden: false,
-      },
-      [grandchildId]: {
-        id: grandchildId,
-        data: { label: 'this is an answer?', children: ['4'] },
-        position: { x: 0, y: 0 },
-        type: 'default',
-        hidden: false,
-      },
-      [greatGrandchildId]: {
-        id: greatGrandchildId,
-        data: { label: 'this is an answer?', children: [] },
-        position: { x: 0, y: 0 },
-        type: 'default',
-        hidden: false,
-      },
-    };
-    render(
-      <ReactFlowProvider>
-        <TestComponent tree={tree} />
-      </ReactFlowProvider>
-    );
-    [parentId, childId, grandchildId, greatGrandchildId].forEach((nodeId: string) => {
-      expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.queryByTestId(`node-${childId}`)!);
-    [parentId, childId].forEach((nodeId) => {
-      expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
-    });
-    [grandchildId, greatGrandchildId].forEach((nodeId) => {
-      expect(screen.queryByTestId(`node-${nodeId}`)).not.toBeInTheDocument();
-    });
-  });
   test('ignores yes/no clicks', () => {
     const parentId = '1';
     const childId = '2';

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -14,11 +14,19 @@ import { afterEach, describe, expect, test } from 'vitest';
 
 const PARENT_ID = '1';
 const YES_CHILD_ID = '2';
-const NO_CHILD_ID = '5';
-const YES_YES_ID = '3';
-const YES_NO_ID = '4';
+const NO_CHILD_ID = '3';
+const YES_YES_ID = '4';
+const YES_NO_ID = '5';
+const NO_YES_ID = '6';
+const NO_NO_ID = '7';
 
-const createTestPositionUnawareDecisionTree = (): PositionUnawareDecisionTree => {
+interface createTestTreeOptions {
+  showIds?: Array<string>;
+}
+
+const createTestPositionUnawareDecisionTree = (
+  options?: createTestTreeOptions
+): PositionUnawareDecisionTree => {
   return {
     [PARENT_ID]: {
       id: PARENT_ID,
@@ -40,25 +48,42 @@ const createTestPositionUnawareDecisionTree = (): PositionUnawareDecisionTree =>
         noId: YES_NO_ID,
       },
       type: 'BoolNode',
-      hidden: true,
+      hidden: !options?.showIds?.includes(YES_CHILD_ID),
     },
     [NO_CHILD_ID]: {
       id: NO_CHILD_ID,
-      data: { label: 'no child', children: [] },
-      type: 'default',
-      hidden: true,
+      data: {
+        label: 'no child',
+        children: [NO_NO_ID, NO_YES_ID],
+        noId: NO_NO_ID,
+        yesId: NO_YES_ID,
+      },
+      type: 'BoolNode',
+      hidden: !options?.showIds?.includes(NO_CHILD_ID),
     },
     [YES_YES_ID]: {
       id: YES_YES_ID,
       data: { label: 'yes grandchild', children: [] },
       type: 'default',
-      hidden: true,
+      hidden: !options?.showIds?.includes(YES_YES_ID),
     },
     [YES_NO_ID]: {
       id: YES_NO_ID,
       data: { label: 'no grandchild', children: [] },
       type: 'default',
-      hidden: true,
+      hidden: !options?.showIds?.includes(YES_NO_ID),
+    },
+    [NO_NO_ID]: {
+      id: NO_NO_ID,
+      data: { label: 'yes grandchild', children: [] },
+      type: 'default',
+      hidden: !options?.showIds?.includes(NO_NO_ID),
+    },
+    [NO_YES_ID]: {
+      id: NO_YES_ID,
+      data: { label: 'no grandchild', children: [] },
+      type: 'default',
+      hidden: !options?.showIds?.includes(NO_YES_ID),
     },
   };
 };
@@ -230,6 +255,24 @@ describe('Tree Component', () => {
       fireEvent.click(screen.queryByTestId(`${PARENT_ID}-yes-button`)!);
       [YES_CHILD_ID, YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
         expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
+      });
+    });
+    test('closes the descendants the selected options siblings', () => {
+      const myTree = createTestPositionUnawareDecisionTree({
+        showIds: [YES_CHILD_ID, NO_CHILD_ID, YES_YES_ID, YES_NO_ID],
+      });
+
+      render(
+        <ReactFlowProvider>
+          <TestComponent tree={myTree} />
+        </ReactFlowProvider>
+      );
+      [YES_CHILD_ID, NO_CHILD_ID, YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
+        expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
+      });
+      fireEvent.click(screen.queryByTestId(`${NO_CHILD_ID}-yes-button`)!);
+      [YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
+        expect(screen.queryByTestId(`node-${nodeId}`)).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -24,14 +24,28 @@ const TestComponent = ({ tree }: { tree?: PositionUnawareDecisionTree }) => {
     },
     ['2']: {
       id: '2',
-      data: { label: 'this is an answer?', children: [] },
+      data: { label: 'this is an answer?', children: [], yesId: '4', noId: '5' },
       position: { x: 0, y: 0 },
-      type: 'default',
+      type: 'BoolNode',
       hidden: false,
     },
     ['3']: {
       id: '3',
       data: { label: 'this is an answer?', children: [] },
+      position: { x: 0, y: 0 },
+      type: 'default',
+      hidden: false,
+    },
+    ['4']: {
+      id: '4',
+      data: { label: 'grandchild 1', children: [] },
+      position: { x: 0, y: 0 },
+      type: 'default',
+      hidden: false,
+    },
+    ['5']: {
+      id: '5',
+      data: { label: 'grandchild 2', children: [] },
       position: { x: 0, y: 0 },
       type: 'default',
       hidden: false,
@@ -244,6 +258,77 @@ describe('Tree Component', () => {
     fireEvent.click(screen.queryByTestId(`node-${parentId}`)!);
     [parentId, childId].forEach((nodeId) => {
       expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
+    });
+  });
+  describe('Making node selection', () => {
+    test('opens the options children', () => {
+      const parentId = '1';
+      const childId = '2';
+      const grandchildId = '4';
+      const otherGrandChild = '5';
+      const myTree = {
+        [parentId]: {
+          id: parentId,
+          data: {
+            label: 'this is a question?',
+            yesId: childId,
+            noId: '3',
+            children: [],
+          },
+          position: { x: 0, y: 0 },
+          type: 'BoolNode',
+          hidden: false,
+        },
+        [childId]: {
+          id: childId,
+          data: {
+            label: 'this is an answer?',
+            children: [grandchildId, otherGrandChild],
+            yesId: grandchildId,
+            noId: otherGrandChild,
+          },
+          position: { x: 0, y: 0 },
+          type: 'BoolNode',
+          hidden: true,
+        },
+        ['3']: {
+          id: '3',
+          data: { label: 'this is an answer?', children: [] },
+          position: { x: 0, y: 0 },
+          type: 'default',
+          hidden: true,
+        },
+        [grandchildId]: {
+          id: grandchildId,
+          data: { label: 'grandchild 1', children: [] },
+          position: { x: 0, y: 0 },
+          type: 'default',
+          hidden: true,
+        },
+        [otherGrandChild]: {
+          id: otherGrandChild,
+          data: { label: 'grandchild 2', children: [] },
+          position: { x: 0, y: 0 },
+          type: 'default',
+          hidden: true,
+        },
+      };
+      render(
+        <ReactFlowProvider>
+          <TestComponent tree={myTree} />
+        </ReactFlowProvider>
+      );
+      [childId, grandchildId, otherGrandChild].forEach((nodeId: string) => {
+        expect(screen.queryByTestId(`node-${nodeId}`)).not.toBeInTheDocument();
+      });
+      fireEvent.click(screen.queryByTestId(`${parentId}-yes-button`)!);
+      // screen.debug();
+      expect(screen.queryByTestId(`node-${childId}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`node-${grandchildId}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`node-${otherGrandChild}`)).toBeInTheDocument();
+      // [childId, grandchildId, otherGrandChild].forEach((nodeId: string) => {
+      //   expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
+      // });
     });
   });
 });


### PR DESCRIPTION
## Description

This PR modifies the behavior of opening and closing nodes. Now, instead of closing all nodes except that of the path taken, we keep immeadiate alternative decisions open as the user passes by. This helps the user see the decisions they made. It's also asthetically pleasing!

## Issue ticket number and link

closes #65 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
