### PR TITLE
Selected path css

### DIFF
--- a/src/components/Tree/Edges/DecisionEdge/DecisionEdge.tsx
+++ b/src/components/Tree/Edges/DecisionEdge/DecisionEdge.tsx
@@ -17,14 +17,17 @@ export const DecisionEdge = (props: DecisionEdgeProps) => {
     targetPosition,
   });
 
+  const edgeZIndex = props.data?.decisionMade ? '100 !important' : '-1 !important';
+
   return (
     <>
       <BaseEdge
         id={id}
         path={edgePath}
         style={{
-          stroke: props.data?.decisionMade ? '#05b485' : '',
+          stroke: props.data?.decisionMade ? '#00754e' : '',
           strokeWidth: '3px',
+          zIndex: edgeZIndex,
         }}
       />
     </>

--- a/src/components/Tree/Nodes/BaseNode/BaseNode.tsx
+++ b/src/components/Tree/Nodes/BaseNode/BaseNode.tsx
@@ -25,7 +25,8 @@ export const BaseNode = ({ id, isConnectable, children, status, helpOnClick }: B
   }, [isHorizontal, updateNodeInternals, id]);
 
   return (
-    <div data-testid={`node-${id}`} className={status ? status : ''}>
+    // <div data-testid={`node-${id}`} className={status ? status : ''}>
+    <div data-testid={`node-${id}`}>
       <Handle
         data-testid={`${isHorizontal ? 'left' : 'top'}-handle`}
         type="target"

--- a/src/components/Tree/Nodes/BaseNode/BaseNode.tsx
+++ b/src/components/Tree/Nodes/BaseNode/BaseNode.tsx
@@ -3,20 +3,19 @@ import styles from 'components/Tree/Nodes/BaseNode/baseNode.module.css';
 import { useTreeDirection } from 'hooks';
 import { ReactNode, useEffect } from 'react';
 import { Handle, NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
-import { DecisionStatus } from 'store/DecisionSlice/decisionSlice';
 
 export interface BaseNodeProps extends Omit<NodeProps, 'data'> {
   children: ReactNode;
-  status?: DecisionStatus;
   helpOnClick?: () => void;
 }
 
 /**
- * A base node that all nodes should extend from.
+ * A base node that all nodes should extend from. It provides the base functionality needed for nodes
+ * to work within the decision tree.
  * @param props
  * @constructor
  */
-export const BaseNode = ({ id, isConnectable, children, status, helpOnClick }: BaseNodeProps) => {
+export const BaseNode = ({ id, isConnectable, children, helpOnClick }: BaseNodeProps) => {
   const updateNodeInternals = useUpdateNodeInternals();
   const [, , isHorizontal] = useTreeDirection();
 

--- a/src/components/Tree/Nodes/BaseNode/baseNode.module.css
+++ b/src/components/Tree/Nodes/BaseNode/baseNode.module.css
@@ -1,6 +1,4 @@
 .nodeContent {
     display: flex;
     justify-content: space-evenly;
-    /*margin: 5px 0 5px 10px;*/
-    /*padding: 10px;*/
 }

--- a/src/components/Tree/Nodes/BaseNode/baseNode.module.css
+++ b/src/components/Tree/Nodes/BaseNode/baseNode.module.css
@@ -1,6 +1,6 @@
 .nodeContent {
     display: flex;
     justify-content: space-evenly;
-    margin: 5px 0 5px 10px;
-    padding: 10px;
+    /*margin: 5px 0 5px 10px;*/
+    /*padding: 10px;*/
 }

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
@@ -103,4 +103,30 @@ describe('BoolNode', () => {
     expect(screen.getByTestId('bool-node-1-content')).toHaveClass(/BoolNodeContent/i);
     expect(screen.getByTestId('bool-node-1-content').classList).toHaveLength(1);
   });
+  test('By default the class contains no status styling', () => {
+    render(
+      <ReactFlowProvider>
+        <BoolNode
+          id={'1'}
+          dragging={false}
+          selected={false}
+          type={''}
+          zIndex={0}
+          isConnectable={false}
+          xPos={0}
+          yPos={0}
+          data={{
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+            status: 'chosen',
+          }}
+        />
+      </ReactFlowProvider>
+    );
+    expect(screen.getByTestId('bool-node-1-content')).toHaveClass(/BoolNodeContent/i);
+    expect(screen.getByTestId('bool-node-1-content')).toHaveClass(/chosen/i);
+    expect(screen.getByTestId('bool-node-1-content').classList).toHaveLength(2);
+  });
 });

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
@@ -98,4 +98,9 @@ describe('BoolNode', () => {
     render(<TestComponent />);
     expect(screen.getByTestId('bool-node-1-content')).toBeInTheDocument();
   });
+  test('By default the class contains no status styling', () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId('bool-node-1-content')).toHaveClass(/BoolNodeContent/i);
+    expect(screen.getByTestId('bool-node-1-content').classList).toHaveLength(1);
+  });
 });

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
@@ -94,4 +94,8 @@ describe('BoolNode', () => {
     expect(noButton).toHaveClass(/selected/i);
     expect(yesButton).not.toHaveClass(/selected/i);
   });
+  test('renders an id we can use during testing', () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId('bool-node-1-content')).toBeInTheDocument();
+  });
 });

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -55,7 +55,7 @@ export const BoolNode = ({
     <BaseNode {...props} id={id}>
       <div
         data-testid={`bool-node-${id}-content`}
-        className={`${styles.boolNodeContent} ${status ?? status}`}
+        className={`${styles.boolNodeContent} ${status ? status : ''}`}
       >
         <div className={styles.boolNodeText}>
           <span>{label}</span>

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -51,9 +51,11 @@ export const BoolNode = ({
     setSelected('no');
   };
 
+  console.log('status', status);
+
   return (
     <BaseNode {...props} id={id} status={status}>
-      <div className={styles.boolNodeContent}>
+      <div className={`${styles.boolNodeContent} ${status ?? status}`}>
         <div className={styles.boolNodeText}>
           <span>{label}</span>
         </div>

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -51,10 +51,8 @@ export const BoolNode = ({
     setSelected('no');
   };
 
-  console.log('status', status);
-
   return (
-    <BaseNode {...props} id={id} status={status}>
+    <BaseNode {...props} id={id}>
       <div className={`${styles.boolNodeContent} ${status ?? status}`}>
         <div className={styles.boolNodeText}>
           <span>{label}</span>

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -53,7 +53,10 @@ export const BoolNode = ({
 
   return (
     <BaseNode {...props} id={id}>
-      <div className={`${styles.boolNodeContent} ${status ?? status}`}>
+      <div
+        data-testid={`bool-node-${id}-content`}
+        className={`${styles.boolNodeContent} ${status ?? status}`}
+      >
         <div className={styles.boolNodeText}>
           <span>{label}</span>
         </div>

--- a/src/components/Tree/Nodes/BoolNode/bool.module.css
+++ b/src/components/Tree/Nodes/BoolNode/bool.module.css
@@ -3,8 +3,8 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    margin: 5px;
-    padding: 10px;
+    padding: 15px;
+    min-width: 300px;
 }
 
 .boolNodeText p {

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.spec.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.spec.tsx
@@ -29,4 +29,25 @@ describe('DefaultNode', () => {
     );
     expect(screen.getByText(myLabel)).toBeInTheDocument();
   });
+  test('renders an id we can use during testing', () => {
+    render(
+      <ReactFlowProvider>
+        <DefaultNode
+          id={'1'}
+          data={{
+            label: 'foo',
+            children: [],
+          }}
+          selected={false}
+          type={''}
+          zIndex={0}
+          isConnectable={false}
+          xPos={0}
+          yPos={0}
+          dragging={false}
+        />
+      </ReactFlowProvider>
+    );
+    expect(screen.getByTestId('default-node-1-content')).toBeInTheDocument();
+  });
 });

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.spec.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.spec.tsx
@@ -2,7 +2,34 @@ import '@testing-library/jest-dom';
 import { cleanup, render, screen } from '@testing-library/react';
 import { DefaultNode } from 'components/Tree/Nodes/DefaultNode/DefaultNode';
 import { ReactFlowProvider } from 'reactflow';
+import { DecisionStatus } from 'store/DecisionSlice/decisionSlice';
 import { afterEach, describe, expect, test } from 'vitest';
+
+interface TestComponentProps {
+  status?: DecisionStatus;
+}
+
+const TestComponent = (props: TestComponentProps) => {
+  return (
+    <ReactFlowProvider>
+      <DefaultNode
+        id={'1'}
+        data={{
+          label: 'foo',
+          children: [],
+          status: props.status,
+        }}
+        selected={false}
+        type={''}
+        zIndex={0}
+        isConnectable={false}
+        xPos={0}
+        yPos={0}
+        dragging={false}
+      />
+    </ReactFlowProvider>
+  );
+};
 
 afterEach(() => cleanup());
 
@@ -30,24 +57,15 @@ describe('DefaultNode', () => {
     expect(screen.getByText(myLabel)).toBeInTheDocument();
   });
   test('renders an id we can use during testing', () => {
-    render(
-      <ReactFlowProvider>
-        <DefaultNode
-          id={'1'}
-          data={{
-            label: 'foo',
-            children: [],
-          }}
-          selected={false}
-          type={''}
-          zIndex={0}
-          isConnectable={false}
-          xPos={0}
-          yPos={0}
-          dragging={false}
-        />
-      </ReactFlowProvider>
-    );
+    render(<TestComponent />);
     expect(screen.getByTestId('default-node-1-content')).toBeInTheDocument();
+  });
+  test('By default only uses default classes', () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId('default-node-1-content').classList).toHaveLength(1);
+  });
+  test('By default only uses default classes', () => {
+    render(<TestComponent status="chosen" />);
+    expect(screen.getByTestId('default-node-1-content').classList).toHaveLength(2);
   });
 });

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
@@ -7,7 +7,10 @@ import { NodeData } from 'store/DecisionSlice/decisionSlice';
 export const DefaultNode = ({ data, ...props }: NodeProps<NodeData>) => {
   return (
     <BaseNode {...props}>
-      <div className={styles.defaultNodeText}>
+      <div
+        data-testid={`default-node-${props.id}-content`}
+        className={`${styles.defaultNodeText} ${data.status ? data.status : ''}`}
+      >
         <span>{data.label}</span>
       </div>
     </BaseNode>

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
@@ -9,7 +9,7 @@ export const DefaultNode = ({ data, ...props }: NodeProps<NodeData>) => {
     <BaseNode {...props}>
       <div
         data-testid={`default-node-${props.id}-content`}
-        className={`${styles.defaultNodeText} ${data.status ? data.status : ''}`}
+        className={`${styles.defaultNodeContent} ${data.status ? data.status : ''}`}
       >
         <span>{data.label}</span>
       </div>

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
@@ -6,7 +6,7 @@ import { NodeData } from 'store/DecisionSlice/decisionSlice';
 
 export const DefaultNode = ({ data, ...props }: NodeProps<NodeData>) => {
   return (
-    <BaseNode {...props} status={data.status}>
+    <BaseNode {...props}>
       <div className={styles.defaultNodeText}>
         <span>{data.label}</span>
       </div>

--- a/src/components/Tree/Nodes/DefaultNode/default.module.css
+++ b/src/components/Tree/Nodes/DefaultNode/default.module.css
@@ -1,8 +1,7 @@
-.defaultNodeText {
+.defaultNodeContent {
     display: flex;
     justify-content: space-around;
     align-items: center;
-    margin: 5px 10px 5px 10px;
     font-size: 1.2em;
-    padding: 10px;
+    padding: 20px;
 }

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -101,24 +101,6 @@ beforeEach(() => {
 
 describe('Tree Component', () => {
   describe('Bool node selection', () => {
-    // test('opens the options children', async () => {
-    //   const user = userEvent.setup();
-    //   const myTree = createTestPositionUnawareDecisionTree();
-    //   render(
-    //     <ReactFlowProvider>
-    //       <TestComponent tree={myTree} />
-    //     </ReactFlowProvider>
-    //   );
-    //   [YES_CHILD_ID, YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
-    //     expect(screen.queryByTestId(`node-${nodeId}`)).not.toBeInTheDocument();
-    //   });
-    //   await user.click(screen.queryByTestId(`${PARENT_ID}-yes-button`)!);
-    //   expect(screen.queryByTestId(`node-${YES_NO_ID}`)).toBeInTheDocument();
-    //   expect(screen.queryByTestId(`node-${YES_YES_ID}`)).toBeInTheDocument();
-    //   // [YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
-    //   //   expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
-    //   // });
-    // });
     test('closes the descendants the selected options siblings', async () => {
       const user = userEvent.setup();
       const myTree = createTestPositionUnawareDecisionTree({

--- a/src/index.css
+++ b/src/index.css
@@ -41,12 +41,23 @@ body {
 }
 
 .chosen {
-    border: 5px solid #05b485;
+    background-color: #00754e;
     border-radius: 20px;
 }
 
+@keyframes focused-gradient {
+    0% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: -100% 50%;
+    }
+}
+
 .focused {
-    border: 5px solid #ec1f1f;
+    background: linear-gradient(90deg, #00754e, #03af58, #00754e);
+    background-size: 200% 200%;
+    animation: focused-gradient 6s linear infinite;
     border-radius: 20px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,6 @@ body {
     color: #fff;
     cursor: auto;
     background: var(--card-color);
-    min-width: 300px;
     border-radius: 20px;
 }
 


### PR DESCRIPTION
## Description

Updates the css of our nodes in the user's selected path through the decision tree. Instead of adding and removing borders, we modify the `background-color` of the node. nodes in the decision tree previously made are a green color to indicate success, the currently focused node is grenn with an animated gradient. 

<img width="808" alt="image" src="https://github.com/USEPA/the-manifest-game/assets/43794491/24db356c-6e68-4fb5-a1af-c28bca9134e0">


## Issue ticket number and link

closes #79 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
