### PR TITLE
Fix help content fetch path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-manifest-game",
-  "version": "0.6.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-manifest-game",
-      "version": "0.6.0",
+      "version": "0.7.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.0.4",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-manifest-game",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useFetchHelp/useFetchHelp.tsx
+++ b/src/hooks/useFetchHelp/useFetchHelp.tsx
@@ -13,7 +13,7 @@ export const useFetchHelp = (nodeId?: string) => {
   useEffect(() => {
     setIsLoading(true);
     if (nodeId) {
-      fetch(`/help/${nodeId}.json`)
+      fetch(`${import.meta.env.BASE_URL}help/${nodeId}.json`)
         .then((response) => {
           if (!response.ok) {
             throw new Error('There was a problem fetching help.');


### PR DESCRIPTION
## Description

Quick fix, since we're using the public directory without importing the files to get their URL as [described in the docs](https://vitejs.dev/guide/assets), we need to prefix our url for getting help content with the vite `BASE_URL`. 

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
