### PR TITLE
modify upload package permissions

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -54,6 +54,8 @@ jobs:
 
   build_container_image:
     name: 'Containerize'
+    permissions:
+      packages: write
     uses: ./.github/workflows/build-image.yaml
     with:
       image_tags: |


### PR DESCRIPTION
add package write permission to build_container_image job in deploy-dev.yaml workflow

## Description

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
