### PR TITLE
Path state

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,6 @@
 name: 'CodeQL'
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -28,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript-typescript']
+        language: [ 'javascript-typescript' ]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -37,6 +37,9 @@ export const BoolNode = ({
   } = useDecisionTree();
 
   const handleYes = () => {
+    // ToDo: This function contains our logic for when a user makes a decision.
+    //  It should be refactored into our useDecisionTree hook and a lot of this logic should be
+    //  abstracted behind the hook's facade.
     showNode(yesId, { parentId: id });
     showChildren(yesId);
     hideNiblings(id);

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -22,7 +22,7 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
     onEdgesChange,
     markDecisionMade,
     markDecisionFocused,
-    updatePath,
+    addDecisionToPath,
   } = useDecTreeStore((state) => state);
 
   /** show a node's direct children and the edges leading to them */
@@ -66,7 +66,7 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
   }, [initialTree, setStoreTree, showStoreNode]);
 
   const addToPath = (source: string, target: string) => {
-    updatePath(source, target);
+    addDecisionToPath(source, target);
   };
 
   return {

--- a/src/store/DagEdgeSlice/dagEdgeSlice.ts
+++ b/src/store/DagEdgeSlice/dagEdgeSlice.ts
@@ -15,9 +15,9 @@ interface DagEdgeSliceActions {
   /** Create an edge */
   createEdge: (sourceId?: string, targetId?: string) => void;
   /** Mark an edge as decision made by source */
-  addEdgeToPath: (source: string, target: string) => void;
+  markEdgeDecided: (source: string, target: string) => void;
   /** Remove an edge from the path by source */
-  removeEdgeFromPathBySource: (source: string) => void;
+  markChildrenEdgesUndecided: (source: string) => void;
 }
 
 export interface DagEdgeSlice extends DagEdgeSliceState, DagEdgeSliceActions {}
@@ -59,7 +59,7 @@ export const createDagEdgeSlice: StateCreator<
       'createEdge'
     );
   },
-  removeEdgeFromPathBySource: (source: string) => {
+  markChildrenEdgesUndecided: (source: string) => {
     const newEdges = get().dagEdges.map((edge) => {
       if (edge.source === source) {
         edge.data = { decisionMade: false };
@@ -74,7 +74,7 @@ export const createDagEdgeSlice: StateCreator<
       'removeEdgeFromPathBySource'
     );
   },
-  addEdgeToPath: (source: string, target: string) => {
+  markEdgeDecided: (source: string, target: string) => {
     const newEdges = get().dagEdges.map((edge) => {
       if (edge.source === source && edge.target === target) {
         edge.style = { stroke: '#05b485', strokeWidth: '3px' };

--- a/src/store/DecisionSlice/decisionSlice.spec.ts
+++ b/src/store/DecisionSlice/decisionSlice.spec.ts
@@ -35,5 +35,23 @@ suite('Decision Slice', () => {
       result.current.setState({ path });
       expect(result.current.getState().getPath()).toEqual(path);
     });
+    test('can remove decisions from the path with the node ID', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      const foo: Decision = { nodeId: 'foo', selected: 'bar' };
+      const bar: Decision = { nodeId: 'bar', selected: 'foobar' };
+      const path: DecisionPath = [foo, bar];
+      result.current.setState({ path });
+      result.current.getState().removeDecisionAndChildren(bar.nodeId);
+      expect(result.current.getState().path).not.toContain(bar);
+    });
+    test('no changes if node ID not in path', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      const foo: Decision = { nodeId: 'foo', selected: 'bar' };
+      const bar: Decision = { nodeId: 'bar', selected: 'foobar' };
+      const path: DecisionPath = [foo, bar];
+      result.current.setState({ path });
+      result.current.getState().removeDecisionAndChildren('undefinedId');
+      expect(result.current.getState().path).toEqual(path);
+    });
   });
 });

--- a/src/store/DecisionSlice/decisionSlice.spec.ts
+++ b/src/store/DecisionSlice/decisionSlice.spec.ts
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { createDecisionSlice, DecisionSlice } from 'store/DecisionSlice/decisionSlice';
+import { describe, expect, suite, test } from 'vitest';
+import { create } from 'zustand';
+
+suite('Decision Slice', () => {
+  describe('Initial State', () => {
+    test('Path is initially empty ', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      expect(result.current.getState().path).toEqual([]);
+    });
+    test('Default direction is left-to-right', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      expect(result.current.getState().direction).toEqual('LR');
+    });
+  });
+});

--- a/src/store/DecisionSlice/decisionSlice.spec.ts
+++ b/src/store/DecisionSlice/decisionSlice.spec.ts
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react';
-import { createDecisionSlice, DecisionSlice } from 'store/DecisionSlice/decisionSlice';
+import {
+  createDecisionSlice,
+  Decision,
+  DecisionPath,
+  DecisionSlice,
+} from 'store/DecisionSlice/decisionSlice';
 import { describe, expect, suite, test } from 'vitest';
 import { create } from 'zustand';
 
@@ -13,6 +18,22 @@ suite('Decision Slice', () => {
     test('Default direction is left-to-right', () => {
       const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
       expect(result.current.getState().direction).toEqual('LR');
+    });
+  });
+  describe('Decision path', () => {
+    test('setter', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      const decision: Decision = { nodeId: 'foo', selected: 'bar' };
+      const path: DecisionPath = [decision];
+      result.current.getState().setPath(path);
+      expect(result.current.getState().path).toContain(decision);
+    });
+    test('getter', () => {
+      const { result } = renderHook(() => create<DecisionSlice>(createDecisionSlice));
+      const decision: Decision = { nodeId: 'foo', selected: 'bar' };
+      const path: DecisionPath = [decision];
+      result.current.setState({ path });
+      expect(result.current.getState().getPath()).toEqual(path);
     });
   });
 });

--- a/src/store/DecisionSlice/decisionSlice.ts
+++ b/src/store/DecisionSlice/decisionSlice.ts
@@ -44,9 +44,17 @@ export type PositionUnawareDecisionTree = Record<string, Omit<TreeNode, 'positio
 
 export type TreeDirection = 'TB' | 'LR';
 
+interface Decision {
+  nodeId: string;
+  selected: string | boolean;
+}
+
+type DecisionPath = Array<Decision>;
+
 interface DecisionSliceState {
   tree: DecisionTree;
   direction: TreeDirection;
+  path: DecisionPath;
 }
 
 interface DecisionSliceActions {
@@ -76,6 +84,7 @@ export const createDecisionSlice: StateCreator<
 > = (set, get) => ({
   direction: 'LR',
   tree: {},
+  path: [],
   setTreeDirection: (direction: TreeDirection) => {
     const tree = layoutTree(get().tree, direction);
     set(

--- a/src/store/DecisionSlice/decisionSlice.ts
+++ b/src/store/DecisionSlice/decisionSlice.ts
@@ -76,6 +76,8 @@ interface DecisionSliceActions {
   setPath: (path: DecisionPath) => void;
   /** get the decision path */
   getPath: () => DecisionPath;
+  /** remove a decision by node ID and all its children */
+  removeDecisionAndChildren: (nodeId: string) => void;
 }
 
 export interface DecisionSlice extends DecisionSliceActions, DecisionSliceState {}
@@ -175,4 +177,17 @@ export const createDecisionSlice: StateCreator<
     );
   },
   getPath: () => get().path,
+  removeDecisionAndChildren: (nodeId: string) => {
+    const path = get().path;
+    const decisionIndex = path.findIndex((decision) => decision.nodeId == nodeId);
+    if (decisionIndex === -1) return;
+    const newPath = path.slice(0, decisionIndex);
+    set(
+      {
+        path: newPath,
+      },
+      false,
+      'removeDecisionAndChildren'
+    );
+  },
 });

--- a/src/store/DecisionSlice/decisionSlice.ts
+++ b/src/store/DecisionSlice/decisionSlice.ts
@@ -44,12 +44,12 @@ export type PositionUnawareDecisionTree = Record<string, Omit<TreeNode, 'positio
 
 export type TreeDirection = 'TB' | 'LR';
 
-interface Decision {
+export interface Decision {
   nodeId: string;
   selected: string | boolean;
 }
 
-type DecisionPath = Array<Decision>;
+export type DecisionPath = Array<Decision>;
 
 interface DecisionSliceState {
   tree: DecisionTree;
@@ -72,6 +72,10 @@ interface DecisionSliceActions {
   collapseDecision: (nodeId: string, children: string[]) => void;
   /** set node as chosen */
   setStatus: (nodeId: string[], status: DecisionStatus) => void;
+  /** set the path of the decision */
+  setPath: (path: DecisionPath) => void;
+  /** get the decision path */
+  getPath: () => DecisionPath;
 }
 
 export interface DecisionSlice extends DecisionSliceActions, DecisionSliceState {}
@@ -161,4 +165,14 @@ export const createDecisionSlice: StateCreator<
       'chooseDecision'
     );
   },
+  setPath: (path: DecisionPath) => {
+    set(
+      {
+        path,
+      },
+      false,
+      'setPath'
+    );
+  },
+  getPath: () => get().path,
 });

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -19,7 +19,7 @@ export interface TreeSlice {
   removeNiblings: (nodeId: string) => void;
   markDecisionMade: (nodeId: string) => void;
   markDecisionFocused: (nodeId: string) => void;
-  updatePath: (source: string, target: string) => void;
+  addDecisionToPath: (source: string, target: string) => void;
 }
 
 /** The state of the tree, implemented as a shared slice that builds on concrete slices
@@ -84,8 +84,12 @@ export const createTreeSlice: StateCreator<
     get().setStatus([...siblingDescendantIds, ...siblings], undefined);
     get().updateDagNodes(get().tree);
   },
-  updatePath: (source: string, target: string) => {
-    get().removeEdgeFromPathBySource(source);
-    get().addEdgeToPath(source, target);
+  addDecisionToPath: (source: string, target: string) => {
+    // Mark all edges from source as undecided
+    get().markChildrenEdgesUndecided(source);
+    // Mark edge from source to target as decided
+    get().markEdgeDecided(source, target);
+    get().removeDecisionAndChildren(source);
+    get().setPath([...get().getPath(), { nodeId: source, selected: target }]);
   },
 });


### PR DESCRIPTION
## Description
Adds state, along with getter, setter, and actions for appending to/remove from the path the user makes through the decision tree. 

Acting on the current path (alering the UI) is outside the scope of this PR. 

We also remove the trigger to run CodeQL workflows on push to main. Since all pushes to main require a PR via github, it's kinda wasteful to run it twice (and it takes a while).  

## Issue ticket number and link

None, but related to #101 and #102 

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
