### PR TITLE
Auto update ancestor decisions

### DIFF
--- a/src/store/DecisionTreeStore/decisionTreeStore.ts
+++ b/src/store/DecisionTreeStore/decisionTreeStore.ts
@@ -6,6 +6,7 @@ import {
 } from 'store/DagNodeSlice/dagNodeSlice';
 import { getDescendantIds, getSiblingIds } from 'store/DecisionTreeStore/decisionTreeStoreUtils';
 import { TreeDirection, TreeSlice } from 'store/TreeSlice/treeSlice';
+import { buildAncestorDecisions } from 'store/TreeSlice/treeSliceUtils';
 import { StateCreator } from 'zustand';
 
 /** The state and actions of the Combined slice*/
@@ -82,7 +83,9 @@ export const createDecisionTreeStore: StateCreator<
     get().setChildrenEdgesUndecided(source);
     get().setEdgeDecided(source, target);
     get().removePathDecision(source);
-    get().setPath([...get().getPath(), { nodeId: source, selected: target }]);
+    const ancestorIds = get().getAncestorDecisions(target);
+    const newDecisions = buildAncestorDecisions(get().tree, ancestorIds);
+    get().setPath([...newDecisions, { nodeId: source, selected: target }]);
   },
   removeDecisionFromPath: (nodeId: string) => {
     const decisionIdsToRemove = getDescendantIds(get().tree, nodeId);

--- a/src/store/TreeSlice/treeSlice.spec.ts
+++ b/src/store/TreeSlice/treeSlice.spec.ts
@@ -82,7 +82,7 @@ suite('Tree Slice', () => {
         },
       };
       result.current.setState({ tree });
-      const ancestors = result.current.getState().getAncestorIds('baz');
+      const ancestors = result.current.getState().getAncestorDecisions('baz');
       expect(ancestors).toEqual(['bar', 'foo']);
     });
   });

--- a/src/store/TreeSlice/treeSlice.spec.ts
+++ b/src/store/TreeSlice/treeSlice.spec.ts
@@ -4,7 +4,7 @@ import { createTreeSlice, Decision, DecisionPath, TreeSlice } from 'store/TreeSl
 import { describe, expect, suite, test } from 'vitest';
 import { create } from 'zustand';
 
-suite('Decision Slice', () => {
+suite('Tree Slice', () => {
   describe('Initial State', () => {
     test('Path is initially empty ', () => {
       const { result } = renderHook(() => create<TreeSlice>(createTreeSlice));
@@ -47,6 +47,43 @@ suite('Decision Slice', () => {
       result.current.setState({ path });
       result.current.getState().removePathDecision('undefinedId');
       expect(result.current.getState().path).toEqual(path);
+    });
+  });
+  describe('Get Ancestor IDs', () => {
+    test('returns ancestor IDs', () => {
+      const { result } = renderHook(() => create<TreeSlice>(createTreeSlice));
+      const tree = {
+        foo: {
+          id: 'foo',
+          hidden: false,
+          data: { label: 'foo', children: ['bar'] },
+          position: {
+            x: 0,
+            y: 0,
+          },
+        },
+        bar: {
+          id: 'bar',
+          hidden: false,
+          data: { label: 'bar', children: ['baz'] },
+          position: {
+            x: 0,
+            y: 0,
+          },
+        },
+        baz: {
+          id: 'baz',
+          hidden: false,
+          data: { label: 'baz', children: [] },
+          position: {
+            x: 0,
+            y: 0,
+          },
+        },
+      };
+      result.current.setState({ tree });
+      const ancestors = result.current.getState().getAncestorIds('baz');
+      expect(ancestors).toEqual(['bar', 'foo']);
     });
   });
 });

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -157,7 +157,6 @@ export const createTreeSlice: StateCreator<
   },
   getAncestorDecisions: (nodeId: string) => {
     const tree = get().tree;
-    const ancestorIds = getAncestorIds(tree, nodeId);
-    return ancestorIds;
+    return getAncestorIds(tree, nodeId);
   },
 });

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -66,7 +66,7 @@ interface TreeSliceActions {
   /** remove a decision by node ID and all its children */
   removePathDecision: (nodeId: string) => void;
   /** get ancestor IDs */
-  getAncestorIds: (nodeId: string) => string[];
+  getAncestorDecisions: (nodeId: string) => string[];
 }
 
 export interface TreeSlice extends TreeSliceActions, TreeSliceState {}
@@ -155,8 +155,9 @@ export const createTreeSlice: StateCreator<
       'removeDecisionFromPath'
     );
   },
-  getAncestorIds: (nodeId: string) => {
+  getAncestorDecisions: (nodeId: string) => {
     const tree = get().tree;
-    return getAncestorIds(tree, nodeId);
+    const ancestorIds = getAncestorIds(tree, nodeId);
+    return ancestorIds;
   },
 });

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -1,6 +1,6 @@
 import { Node } from 'reactflow';
 import { layoutTree } from 'store/TreeSlice/layout';
-import { setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
+import { getAncestorIds, setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
 import { StateCreator } from 'zustand';
 
 export type VertexStatus = 'unselect' | 'chosen' | 'focused' | undefined;
@@ -65,6 +65,8 @@ interface TreeSliceActions {
   getPath: () => DecisionPath;
   /** remove a decision by node ID and all its children */
   removePathDecision: (nodeId: string) => void;
+  /** get ancestor IDs */
+  getAncestorIds: (nodeId: string) => string[];
 }
 
 export interface TreeSlice extends TreeSliceActions, TreeSliceState {}
@@ -152,5 +154,9 @@ export const createTreeSlice: StateCreator<
       false,
       'removeDecisionFromPath'
     );
+  },
+  getAncestorIds: (nodeId: string) => {
+    const tree = get().tree;
+    return getAncestorIds(tree, nodeId);
   },
 });

--- a/src/store/TreeSlice/treeSliceUtils.spec.ts
+++ b/src/store/TreeSlice/treeSliceUtils.spec.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
+import { getAncestorIds, setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
 import { describe, expect, suite, test } from 'vitest';
 
 suite('Tree Slice internals', () => {
@@ -26,6 +26,49 @@ suite('Tree Slice internals', () => {
       expect(updatedTree['1'].hidden).toBe(true);
       const idempotentTree = setNodesHidden(updatedTree, ['1']);
       expect(idempotentTree['1'].hidden).toBe(true);
+    });
+  });
+  describe('Get Ancestor IDs', () => {
+    const parent = 'foo';
+    const child = 'bar';
+    const grandparent = 'baz';
+    const data: DecisionTree = {
+      [grandparent]: {
+        id: grandparent,
+        hidden: false,
+        data: { label: grandparent, children: [parent] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+      [parent]: {
+        id: parent,
+        hidden: false,
+        data: { label: parent, children: [child] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+      child: {
+        id: child,
+        hidden: false,
+        data: { label: child, children: [] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+    };
+    test('Returns an array', () => {
+      expect(getAncestorIds(data, parent)).toBeInstanceOf(Array);
+    });
+    test('Returns an empty array if the node has no ancestors', () => {
+      expect(getAncestorIds(data, grandparent)).toEqual([]);
+    });
+    test('Returns the parent and grandparent node IDs', () => {
+      expect(getAncestorIds(data, child)).toEqual([parent, grandparent]);
     });
   });
 });

--- a/src/store/TreeSlice/treeSliceUtils.spec.ts
+++ b/src/store/TreeSlice/treeSliceUtils.spec.ts
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom';
 import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
-import { getAncestorIds, setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
+import {
+  buildAncestorDecisions,
+  getAncestorIds,
+  setNodesHidden,
+  setNodeVisible,
+} from 'store/TreeSlice/treeSliceUtils';
 import { describe, expect, suite, test } from 'vitest';
 
 suite('Tree Slice internals', () => {
@@ -69,6 +74,60 @@ suite('Tree Slice internals', () => {
     });
     test('Returns the parent and grandparent node IDs', () => {
       expect(getAncestorIds(data, child)).toEqual([parent, grandparent]);
+    });
+  });
+  describe('build ancestor decisions', () => {
+    const parent = 'foo';
+    const child = 'bar';
+    const grandparent = 'baz';
+    const uncle = 'uncle';
+    const data: DecisionTree = {
+      [grandparent]: {
+        id: grandparent,
+        hidden: false,
+        data: { label: grandparent, children: [parent, uncle] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+      [parent]: {
+        id: parent,
+        hidden: false,
+        data: { label: parent, children: [child] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+      [uncle]: {
+        id: uncle,
+        hidden: false,
+        data: { label: uncle, children: [] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+      child: {
+        id: child,
+        hidden: false,
+        data: { label: child, children: [] },
+        position: {
+          x: 0,
+          y: 0,
+        },
+      },
+    };
+    test('Returns an array', () => {
+      expect(buildAncestorDecisions(data, [parent, grandparent])).toBeInstanceOf(Array);
+    });
+    test('returns an array of objects with the decisions', () => {
+      const decisions = buildAncestorDecisions(data, [parent, grandparent]);
+      decisions.map((decision) => {
+        expect(decision.nodeId).toBeDefined();
+        expect(decision.selected).toBeDefined();
+      });
     });
   });
 });

--- a/src/store/TreeSlice/treeSliceUtils.ts
+++ b/src/store/TreeSlice/treeSliceUtils.ts
@@ -16,6 +16,7 @@ export const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
 export const getAncestorIds = (tree: DecisionTree, nodeId: string): string[] => {
   const ancestors: string[] = [];
   Object.values(tree).forEach((node) => {
+    if (!node.data.children) return;
     if (node.data.children.includes(nodeId)) {
       ancestors.push(node.id);
       ancestors.push(...getAncestorIds(tree, node.id));
@@ -26,15 +27,13 @@ export const getAncestorIds = (tree: DecisionTree, nodeId: string): string[] => 
 
 /** convert ancestor ids to ancestor decisions */
 export const buildAncestorDecisions = (tree: DecisionTree, ancestorIds: string[]): DecisionPath => {
-  // @ts-expect-error - ToDo fix this typescript error to check for situations where the selected answer is not found
-  return ancestorIds.map((id) => {
+  const decisions: DecisionPath = [];
+  ancestorIds.map((id) => {
     const node = tree[id];
-    // ToDo break this into smaller function
-    const selectedAnswer = node.data.children.find((childId) =>
-      ancestorIds.filter((choice) => {
-        if (childId === choice) return choice;
-      })
-    );
-    return { nodeId: node.id, selected: selectedAnswer };
+    const selectedAnswer = node.data.children.find((childId) => ancestorIds.includes(childId));
+    if (selectedAnswer) {
+      decisions.push({ nodeId: node.id, selected: selectedAnswer });
+    }
   });
+  return decisions;
 };

--- a/src/store/TreeSlice/treeSliceUtils.ts
+++ b/src/store/TreeSlice/treeSliceUtils.ts
@@ -11,3 +11,14 @@ export const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
   nodeIds.forEach((id) => (tree[id].hidden = true));
   return tree;
 };
+
+export const getAncestorIds = (tree: DecisionTree, nodeId: string): string[] => {
+  const ancestors: string[] = [];
+  Object.values(tree).forEach((node) => {
+    if (node.data.children.includes(nodeId)) {
+      ancestors.push(node.id);
+      ancestors.push(...getAncestorIds(tree, node.id));
+    }
+  });
+  return ancestors;
+};

--- a/src/store/TreeSlice/treeSliceUtils.ts
+++ b/src/store/TreeSlice/treeSliceUtils.ts
@@ -1,4 +1,4 @@
-import { DecisionTree } from 'store/TreeSlice/treeSlice';
+import { DecisionPath, DecisionTree } from 'store/TreeSlice/treeSlice';
 
 /** set hidden to false */
 export const setNodeVisible = (tree: DecisionTree, nodeIds: string[]) => {
@@ -12,6 +12,7 @@ export const setNodesHidden = (tree: DecisionTree, nodeIds: string[]) => {
   return tree;
 };
 
+/** find all ancestor ids */
 export const getAncestorIds = (tree: DecisionTree, nodeId: string): string[] => {
   const ancestors: string[] = [];
   Object.values(tree).forEach((node) => {
@@ -21,4 +22,19 @@ export const getAncestorIds = (tree: DecisionTree, nodeId: string): string[] => 
     }
   });
   return ancestors;
+};
+
+/** convert ancestor ids to ancestor decisions */
+export const buildAncestorDecisions = (tree: DecisionTree, ancestorIds: string[]): DecisionPath => {
+  // @ts-expect-error - ToDo fix this typescript error to check for situations where the selected answer is not found
+  return ancestorIds.map((id) => {
+    const node = tree[id];
+    // ToDo break this into smaller function
+    const selectedAnswer = node.data.children.find((childId) =>
+      ancestorIds.filter((choice) => {
+        if (childId === choice) return choice;
+      })
+    );
+    return { nodeId: node.id, selected: selectedAnswer };
+  });
 };


### PR DESCRIPTION
## Description

This PR updates the decision tree logic to automatically update the decisions of previous nodes when nodes are skipped. 

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
