### PR TITLE
Update url with current decision

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from 'App';
 import { delay, http, HttpResponse } from 'msw';
@@ -7,6 +7,7 @@ import { setupServer } from 'msw/node';
 import React from 'react';
 import { ReactFlowProvider } from 'reactflow';
 import useTreeStore from 'store';
+import { renderWithProviders } from 'test-utils';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 const TestComponent = () => {
@@ -65,36 +66,36 @@ describe('App', () => {
         });
       })
     );
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
   test('renders a title if provided', async () => {
     const title = 'Zee bananas';
     vi.stubEnv('VITE_APP_TITLE', title);
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByText(title)).toBeInTheDocument();
   });
   test('defaults title to "The Manifest Game"', async () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByText('The Manifest Game')).toBeInTheDocument();
   });
   test('minimap is visible by default', async () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByTestId(/minimap/i)).toBeInTheDocument();
   });
   test('Throws an error if there is an error fetching the config', async () => {
     server.use(http.get('/default.json', async () => HttpResponse.error()));
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByText(/Error/i)).toBeInTheDocument();
   });
   test('the help content is closed onClicking the close button', async () => {
     const user = userEvent.setup();
     useTreeStore.setState({ helpIsOpen: true });
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     await waitFor(() => expect(screen.queryByTestId('spinner')).not.toBeInTheDocument());
     expect(screen.getByTestId('offcanvas')).toBeInTheDocument();
     const closeButton = screen.getByRole('button', { name: /close/i });

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.spec.tsx
@@ -1,9 +1,10 @@
 import '@testing-library/jest-dom';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BoolNode, BoolNodeData } from 'components/Tree/Nodes/BoolNode/BoolNode';
 import { NodeProps, ReactFlowProvider } from 'reactflow';
 import useTreeStore from 'store';
+import { renderWithProviders } from 'test-utils';
 import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => cleanup());
@@ -71,97 +72,91 @@ describe('BoolNode', () => {
   test('renders a node', () => {
     const label = 'what site type?';
     // @ts-expect-error - don't need to pass all props
-    render(<TestComponent overwrites={{ data: { label } }} />);
+    renderWithProviders(<TestComponent overwrites={{ data: { label } }} />);
     expect(screen.getByText(label)).toBeInTheDocument();
   });
   test('renders a yes and no button', () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     expect(screen.getByRole('button', { name: /yes/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /no/i })).toBeInTheDocument();
   });
   test('yes and no initially do not have selected class name', () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     expect(screen.getByRole('button', { name: /yes/i })).not.toHaveClass(/selected/i);
   });
   test('renders an id we can use during testing', () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     expect(screen.getByTestId('bool-node-1-content')).toBeInTheDocument();
   });
   test('By default the class contains to animations', () => {
-    render(<TestComponent />);
+    renderWithProviders(<TestComponent />);
     expect(screen.getByTestId('bool-node-1-content')).not.toHaveClass(/animated/i);
   });
   describe('Help Icon', () => {
     test('not displayed when falsy', () => {
-      render(
-        <ReactFlowProvider>
-          <BoolNode
-            id={'1'}
-            dragging={false}
-            selected={false}
-            type={''}
-            zIndex={0}
-            isConnectable={false}
-            xPos={0}
-            yPos={0}
-            data={{
-              label: 'this is a question?',
-              yesId: '2',
-              noId: '3',
-              children: [],
-            }}
-          />
-        </ReactFlowProvider>
+      renderWithProviders(
+        <BoolNode
+          id={'1'}
+          dragging={false}
+          selected={false}
+          type={''}
+          zIndex={0}
+          isConnectable={false}
+          xPos={0}
+          yPos={0}
+          data={{
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+          }}
+        />
       );
       expect(screen.queryByLabelText(/help/i)).not.toBeInTheDocument();
     });
     test('displayed icon when truthy', () => {
-      render(
-        <ReactFlowProvider>
-          <BoolNode
-            id={'1'}
-            dragging={false}
-            selected={false}
-            type={''}
-            zIndex={0}
-            isConnectable={false}
-            xPos={0}
-            yPos={0}
-            data={{
-              label: 'this is a question?',
-              yesId: '2',
-              noId: '3',
-              children: [],
-              help: 'root.json',
-            }}
-          />
-        </ReactFlowProvider>
+      renderWithProviders(
+        <BoolNode
+          id={'1'}
+          dragging={false}
+          selected={false}
+          type={''}
+          zIndex={0}
+          isConnectable={false}
+          xPos={0}
+          yPos={0}
+          data={{
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+            help: 'root.json',
+          }}
+        />
       );
       expect(screen.queryByLabelText(/more information/i)).toBeInTheDocument();
     });
     test('ToDo: handles onClick events', async () => {
       // ToDo: This test does not assert anything
       const user = userEvent.setup();
-      render(
-        <ReactFlowProvider>
-          <BoolNode
-            id={'1'}
-            dragging={false}
-            selected={false}
-            type={''}
-            zIndex={0}
-            isConnectable={false}
-            xPos={0}
-            yPos={0}
-            data={{
-              label: 'this is a question?',
-              yesId: '2',
-              noId: '3',
-              children: [],
-              help: 'foo.json',
-            }}
-          />
-        </ReactFlowProvider>
+      renderWithProviders(
+        <BoolNode
+          id={'1'}
+          dragging={false}
+          selected={false}
+          type={''}
+          zIndex={0}
+          isConnectable={false}
+          xPos={0}
+          yPos={0}
+          data={{
+            label: 'this is a question?',
+            yesId: '2',
+            noId: '3',
+            children: [],
+            help: 'foo.json',
+          }}
+        />
       );
       const helpIcon = screen.getByLabelText(/more information/i);
       await user.click(helpIcon);

--- a/src/components/Tree/Tree.spec.tsx
+++ b/src/components/Tree/Tree.spec.tsx
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Tree } from 'components/Tree/Tree';
 import { useDecisionTree } from 'hooks';
-import { ReactFlowProvider } from 'reactflow';
 import useTreeStore, { PositionUnawareDecisionTree } from 'store';
+import { renderWithProviders } from 'test-utils';
 import { beforeEach, describe, expect, test } from 'vitest';
 
 //                     parent
@@ -106,11 +106,7 @@ describe('Tree Component', () => {
       const myTree = createTestPositionUnawareDecisionTree({
         showIds: [YES_CHILD_ID, NO_CHILD_ID, YES_YES_ID, YES_NO_ID],
       });
-      render(
-        <ReactFlowProvider>
-          <TestComponent tree={myTree} />
-        </ReactFlowProvider>
-      );
+      renderWithProviders(<TestComponent tree={myTree} />);
       [YES_CHILD_ID, NO_CHILD_ID, YES_YES_ID, YES_NO_ID].forEach((nodeId: string) => {
         expect(screen.queryByTestId(`node-${nodeId}`)).toBeInTheDocument();
       });

--- a/src/hooks/useDecisionTree/useDecisionTree.spec.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.spec.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDecisionTree } from 'hooks/useDecisionTree/useDecisionTree';
-import { ReactFlowProvider } from 'reactflow';
 import { DecisionTree } from 'store';
+import { renderWithProviders } from 'test-utils';
 import { afterEach, describe, expect, test } from 'vitest';
 
 afterEach(() => cleanup());
@@ -40,11 +40,7 @@ describe('useDecisionTree', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(
-      <ReactFlowProvider>
-        <TestComponent initialTree={initialTree} />
-      </ReactFlowProvider>
-    );
+    renderWithProviders(<TestComponent initialTree={initialTree} />);
     expect(screen.getByText(/node id: 1/i)).toBeInTheDocument();
   });
   test('un-hides nodes based on the user input', async () => {
@@ -65,11 +61,7 @@ describe('useDecisionTree', () => {
         position: { x: 0, y: 0, rank: 0 },
       },
     };
-    render(
-      <ReactFlowProvider>
-        <TestComponent initialTree={initialTree} showNodeId={childId} />
-      </ReactFlowProvider>
-    );
+    renderWithProviders(<TestComponent initialTree={initialTree} showNodeId={childId} />);
     expect(screen.queryByText(/node id: 2/i)).not.toBeInTheDocument();
     await user.click(screen.getByText(/show node/i));
     expect(screen.queryByText(/node id: 2/i)).toBeInTheDocument();

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -1,4 +1,5 @@
 import { useTreeViewport } from 'hooks/useTreeViewport/useTreeViewport';
+import { useUrl } from 'hooks/useUrl/useUrl';
 import { useEffect } from 'react';
 import useDecTreeStore, { PositionUnawareDecisionTree } from 'store';
 
@@ -22,6 +23,7 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
     addDecisionToPath,
     removeDecisionFromPath,
   } = useDecTreeStore((state) => state);
+  const { setPathParam } = useUrl();
 
   const focusNode = (nodeId: string) => {
     setCenter(tree[nodeId].position.x + 50, tree[nodeId].position.y + 50, {
@@ -46,6 +48,7 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
     showChildren(target);
     hideNiblings(source);
     addDecisionToPath(source, target);
+    setPathParam(target);
   };
 
   const retractDecision = (target: string) => {

--- a/src/hooks/useUrl/useUrl.spec.tsx
+++ b/src/hooks/useUrl/useUrl.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useUrl } from 'hooks/useUrl/useUrl';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -11,7 +11,7 @@ const wrapper = ({ children }: { children: ReactNode }) => {
 suite('useUrl hook', () => {
   test('pathQueryParam is falsy by default', () => {
     const { result } = renderHook(() => useUrl(), { wrapper });
-    expect(result.current.pathQueryParam).toBeFalsy();
+    expect(result.current.pathParam).toBeFalsy();
   });
   test('returns the path URL query param', () => {
     const pathQueryParam = 'foo';
@@ -19,6 +19,14 @@ suite('useUrl hook', () => {
       return <MemoryRouter initialEntries={[`?path=${pathQueryParam}`]}>{children}</MemoryRouter>;
     };
     const { result } = renderHook(() => useUrl(), { wrapper });
-    expect(result.current.pathQueryParam).toBe(pathQueryParam);
+    expect(result.current.pathParam).toBe(pathQueryParam);
+  });
+  test('returns the path URL query param', async () => {
+    const pathQueryParam = 'foo';
+    const { result } = renderHook(() => useUrl(), { wrapper });
+    await act(async () => {
+      result.current.setPathParam(pathQueryParam);
+    });
+    expect(result.current.pathParam).toBe(pathQueryParam);
   });
 });

--- a/src/hooks/useUrl/useUrl.spec.tsx
+++ b/src/hooks/useUrl/useUrl.spec.tsx
@@ -1,11 +1,24 @@
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react';
 import { useUrl } from 'hooks/useUrl/useUrl';
+import React, { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { expect, suite, test } from 'vitest';
 
+const wrapper = ({ children }: { children: ReactNode }) => {
+  return <MemoryRouter>{children}</MemoryRouter>;
+};
 suite('useUrl hook', () => {
-  test('returns the current path', () => {
-    const { result } = renderHook(() => useUrl());
+  test('pathQueryParam is falsy by default', () => {
+    const { result } = renderHook(() => useUrl(), { wrapper });
     expect(result.current.pathQueryParam).toBeFalsy();
+  });
+  test('returns the path URL query param', () => {
+    const pathQueryParam = 'foo';
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return <MemoryRouter initialEntries={[`?path=${pathQueryParam}`]}>{children}</MemoryRouter>;
+    };
+    const { result } = renderHook(() => useUrl(), { wrapper });
+    expect(result.current.pathQueryParam).toBe(pathQueryParam);
   });
 });

--- a/src/hooks/useUrl/useUrl.spec.tsx
+++ b/src/hooks/useUrl/useUrl.spec.tsx
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { useUrl } from 'hooks/useUrl/useUrl';
+import { expect, suite, test } from 'vitest';
+
+suite('useUrl hook', () => {
+  test('returns the current path', () => {
+    const { result } = renderHook(() => useUrl());
+    expect(result.current.pathQueryParam).toBeFalsy();
+  });
+});

--- a/src/hooks/useUrl/useUrl.tsx
+++ b/src/hooks/useUrl/useUrl.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export interface UsesPathReturn {
+  pathQueryParam: string;
+}
+
+/**
+ * custom hook for interacting with the path taken through the decision tree
+ */
+export const useUrl = () => {
+  const [pathQueryParam] = useState<string | null | undefined>();
+
+  return {
+    pathQueryParam,
+  } as UsesPathReturn;
+};

--- a/src/hooks/useUrl/useUrl.tsx
+++ b/src/hooks/useUrl/useUrl.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 export interface UsesPathReturn {
   pathQueryParam: string;
@@ -8,7 +9,8 @@ export interface UsesPathReturn {
  * custom hook for interacting with the path taken through the decision tree
  */
 export const useUrl = () => {
-  const [pathQueryParam] = useState<string | null | undefined>();
+  const [urlQueryParams, setUrlQueryParams] = useSearchParams();
+  const [pathQueryParam] = useState<string | null | undefined>(urlQueryParams.get('path'));
 
   return {
     pathQueryParam,

--- a/src/hooks/useUrl/useUrl.tsx
+++ b/src/hooks/useUrl/useUrl.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export interface UsesPathReturn {
-  pathQueryParam: string;
+  pathParam: string;
+  setPathParam: (pathId: string) => void;
 }
 
 /**
@@ -10,9 +11,16 @@ export interface UsesPathReturn {
  */
 export const useUrl = () => {
   const [urlQueryParams, setUrlQueryParams] = useSearchParams();
-  const [pathQueryParam] = useState<string | null | undefined>(urlQueryParams.get('path'));
+  const [pathParam, setPathParam] = useState<string | null | undefined>(urlQueryParams.get('path'));
+
+  const setUrlPathId = (pathId: string) => {
+    urlQueryParams.set('path', pathId);
+    setUrlQueryParams(urlQueryParams);
+    setPathParam(pathId);
+  };
 
   return {
-    pathQueryParam,
+    pathParam,
+    setPathParam: setUrlPathId,
   } as UsesPathReturn;
 };

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,32 @@
+import { render, RenderOptions } from '@testing-library/react';
+import React, { PropsWithChildren, ReactElement } from 'react';
+import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
+import { ReactFlowProvider } from 'reactflow';
+
+interface DecisionTreeRenderOptions extends RenderOptions {
+  memoryRouterProps?: MemoryRouterProps;
+}
+
+/**
+ * @description
+ * A utility wrapper for testing we do not need to render misc providers in all tests,
+ * and our components can remain unaware of each other. see:
+ * https://testing-library.com/docs/react-testing-library/setup/#custom-render
+ */
+export function renderWithProviders(
+  ui: React.ReactElement,
+  {
+    memoryRouterProps,
+    ...renderOptions // react-testing library function options
+  }: DecisionTreeRenderOptions = {} // default to empty object
+) {
+  function Wrapper({ children }: PropsWithChildren<object>): ReactElement {
+    return (
+      <MemoryRouter {...memoryRouterProps}>
+        <ReactFlowProvider>{children}</ReactFlowProvider>
+      </MemoryRouter>
+    );
+  }
+
+  return { ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
+}


### PR DESCRIPTION
## Description

updates a query parameter in the URL when the user makes a decision.

I also went ahead a create a new `renderWithProviders` test utility function which removed the need to include react context providers for tests that don't need to know about that information. This was a needed fix since we now need a route provider from the `react-router-dom` library for a couple of our hooks. 

## Issue ticket number and link

closes #98 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
