### PR TITLE
Render decision tree based on url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Tree } from 'components/Tree/Tree';
 import { useDecisionTree } from 'hooks';
 import { useFetchConfig } from 'hooks/useFetchConfig/useFetchConfig';
 import { useHelp } from 'hooks/useHelp/useHelp';
+import { useUrl } from 'hooks/useUrl/useUrl';
 
 /**
  * App - responsible for rendering the decision tree
@@ -16,7 +17,8 @@ import { useHelp } from 'hooks/useHelp/useHelp';
 export default function App() {
   const title = import.meta.env.VITE_APP_TITLE ?? 'The Manifest Game';
   const { config, isLoading: configIsLoading, error: configError } = useFetchConfig(defaultTree);
-  const { nodes, edges } = useDecisionTree(config);
+  const { pathParam } = useUrl();
+  const { nodes, edges } = useDecisionTree(config, pathParam);
   const { helpIsOpen, hideHelp } = useHelp();
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,6 @@ export default function App() {
   const { nodes, edges } = useDecisionTree(config);
   const { helpIsOpen, hideHelp } = useHelp();
 
-  const handleHelpClose = () => {
-    hideHelp();
-  };
-
   return (
     <>
       <BackgroundImage />
@@ -36,7 +32,7 @@ export default function App() {
           <Tree nodes={nodes} edges={edges} />
         </>
       )}
-      <OffCanvas isOpen={helpIsOpen} handleClose={handleHelpClose} />
+      <OffCanvas isOpen={helpIsOpen} onClose={hideHelp} />
     </>
   );
 }

--- a/src/components/OffCanvas/OffCanvas.tsx
+++ b/src/components/OffCanvas/OffCanvas.tsx
@@ -4,29 +4,29 @@ import { FaX } from 'react-icons/fa6';
 
 interface OffCanvasProps {
   isOpen: boolean;
-  handleClose: () => void;
+  onClose: () => void;
 }
 
 /**
  * Sidebar for displaying content and help
  * @constructor
  */
-export const OffCanvas = ({ isOpen, handleClose }: OffCanvasProps) => {
+export const OffCanvas = ({ isOpen, onClose }: OffCanvasProps) => {
   /** handle when user clicks outside the off canvas component*/
   const onClickOutside = useCallback(() => {
     if (isOpen) {
-      if (handleClose) handleClose();
+      if (onClose) onClose();
     }
-  }, [isOpen, handleClose]);
+  }, [isOpen, onClose]);
 
   /** handle when user presses the escape key */
   const onEscKey = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isOpen) {
-        if (handleClose) handleClose();
+        if (onClose) onClose();
       }
     },
-    [isOpen, handleClose]
+    [isOpen, onClose]
   );
 
   /** add event listeners for escape key keydown*/
@@ -62,7 +62,7 @@ export const OffCanvas = ({ isOpen, handleClose }: OffCanvasProps) => {
             className="text-gray800 rounded-full p-1 transition-colors duration-200 ease-in-out
             hover:text-gray-900 focus:outline-none focus:ring
             focus:ring-gray-800 active:text-gray-900"
-            onClick={handleClose}
+            onClick={onClose}
             type="button"
             tabIndex={0}
             aria-label="Close"

--- a/src/components/OffCanvas/Offcanvas.spec.tsx
+++ b/src/components/OffCanvas/Offcanvas.spec.tsx
@@ -7,21 +7,21 @@ afterEach(() => cleanup());
 
 describe('OffCanvas', () => {
   test('renders', () => {
-    render(<OffCanvas isOpen={true} handleClose={() => undefined} />);
+    render(<OffCanvas isOpen={true} onClose={() => undefined} />);
     expect(screen.getByTestId(/offcanvas/i)).toBeInTheDocument();
   });
 
   test('handles close event', () => {
     const handleClose = vi.fn();
-    render(<OffCanvas isOpen={true} handleClose={handleClose} />);
+    render(<OffCanvas isOpen={true} onClose={handleClose} />);
     screen.getByRole('button', { name: /close/i }).click();
     expect(handleClose).toHaveBeenCalled();
   });
   test('closes modal when user clicks close', () => {
     const handleClose = vi.fn();
-    const { rerender } = render(<OffCanvas isOpen={true} handleClose={handleClose} />);
+    const { rerender } = render(<OffCanvas isOpen={true} onClose={handleClose} />);
     expect(screen.getByTestId(/offcanvas/i)).toBeVisible();
-    rerender(<OffCanvas isOpen={false} handleClose={handleClose} />);
+    rerender(<OffCanvas isOpen={false} onClose={handleClose} />);
     expect(screen.getByTestId(/offcanvas/i)).not.toBeVisible();
   });
 });

--- a/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
+++ b/src/components/Tree/Nodes/BoolNode/BoolNode.tsx
@@ -24,8 +24,12 @@ export const BoolNode = ({
   const { decisionIsInPath, decision, isCurrentDecision } = useDecisions(id);
 
   const handleHelpClick: MouseEventHandler = (event) => {
-    showHelp(help);
-    event.stopPropagation();
+    try {
+      showHelp(help);
+      event.stopPropagation();
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const handleAnswer = (answer: boolean) => (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
+++ b/src/components/Tree/Nodes/DefaultNode/DefaultNode.tsx
@@ -11,8 +11,12 @@ export const DefaultNode = ({ data, ...props }: NodeProps<VertexData>) => {
   const { isCurrentDecision } = useDecisions(props.id);
 
   const handleHelpClick: MouseEventHandler = (event) => {
-    showHelp(props.id);
-    event.stopPropagation();
+    try {
+      showHelp(props.id);
+      event.stopPropagation();
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const nodeBackgroundColor = isCurrentDecision

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -22,7 +22,6 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
     onEdgesChange,
     addDecisionToPath,
     removeDecisionFromPath,
-    buildPathToNode,
     getParentVertexId,
     getPath,
   } = useDecTreeStore((state) => state);
@@ -55,9 +54,9 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
     addDecisionToPath,
     initialTree,
     pathParam,
-    buildPathToNode,
     setDecisionTree,
     showNode,
+    getParentVertexId,
   ]);
 
   const makeDecision = (source: string, target: string) => {

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -23,6 +23,8 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
     addDecisionToPath,
     removeDecisionFromPath,
     buildPathToNode,
+    getParentVertexId,
+    getPath,
   } = useDecTreeStore((state) => state);
 
   const focusNode = (nodeId: string) => {
@@ -40,10 +42,23 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
         if (!node.hidden) showNode(node.id);
       });
       if (pathParam) {
-        buildPathToNode(pathParam);
+        const parent = getParentVertexId(pathParam);
+        if (parent) addDecisionToPath(parent, pathParam);
+        getPath().forEach((decision) => {
+          showChildren(decision.nodeId);
+        });
       }
     }
-  }, [initialTree, pathParam, buildPathToNode, setDecisionTree, showNode]);
+  }, [
+    getPath,
+    showChildren,
+    addDecisionToPath,
+    initialTree,
+    pathParam,
+    buildPathToNode,
+    setDecisionTree,
+    showNode,
+  ]);
 
   const makeDecision = (source: string, target: string) => {
     showNode(target, { parentId: source });

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -1,13 +1,13 @@
 import { useTreeViewport } from 'hooks/useTreeViewport/useTreeViewport';
-import { useUrl } from 'hooks/useUrl/useUrl';
 import { useEffect } from 'react';
 import useDecTreeStore, { PositionUnawareDecisionTree } from 'store';
 
 /**
  * custom hook that wraps around the tree store to provide a simplified interface for common tasks
  * @param initialTree
+ * @param pathParam
  */
-export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
+export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathParam?: string) => {
   const { setCenter, getZoom } = useTreeViewport();
   const {
     tree,
@@ -23,7 +23,8 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
     addDecisionToPath,
     removeDecisionFromPath,
   } = useDecTreeStore((state) => state);
-  const { setPathParam } = useUrl();
+
+  console.log(pathParam);
 
   const focusNode = (nodeId: string) => {
     setCenter(tree[nodeId].position.x + 50, tree[nodeId].position.y + 50, {
@@ -48,7 +49,6 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree) => {
     showChildren(target);
     hideNiblings(source);
     addDecisionToPath(source, target);
-    setPathParam(target);
   };
 
   const retractDecision = (target: string) => {

--- a/src/hooks/useDecisionTree/useDecisionTree.tsx
+++ b/src/hooks/useDecisionTree/useDecisionTree.tsx
@@ -22,9 +22,8 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
     onEdgesChange,
     addDecisionToPath,
     removeDecisionFromPath,
+    buildPathToNode,
   } = useDecTreeStore((state) => state);
-
-  console.log(pathParam);
 
   const focusNode = (nodeId: string) => {
     setCenter(tree[nodeId].position.x + 50, tree[nodeId].position.y + 50, {
@@ -40,8 +39,11 @@ export const useDecisionTree = (initialTree?: PositionUnawareDecisionTree, pathP
       Object.values(initialTree).forEach((node) => {
         if (!node.hidden) showNode(node.id);
       });
+      if (pathParam) {
+        buildPathToNode(pathParam);
+      }
     }
-  }, [initialTree, setDecisionTree, showNode]);
+  }, [initialTree, pathParam, buildPathToNode, setDecisionTree, showNode]);
 
   const makeDecision = (source: string, target: string) => {
     showNode(target, { parentId: source });

--- a/src/hooks/useHelp/useHelp.spec.tsx
+++ b/src/hooks/useHelp/useHelp.spec.tsx
@@ -1,11 +1,15 @@
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react';
 import { useHelp } from 'hooks/useHelp/useHelp';
-import { expect, suite, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-suite('useHelp hook', () => {
+describe('useHelp hook', () => {
   test('helpIsOpen is initially false', () => {
     const { result } = renderHook(() => useHelp());
     expect(result.current.helpIsOpen).toBe(false);
+  });
+  test('showHelp returns if arg is undefined', () => {
+    const { result } = renderHook(() => useHelp());
+    expect(() => result.current.showHelp(undefined)).toThrowError('contentId is required');
   });
 });

--- a/src/hooks/useHelp/useHelp.tsx
+++ b/src/hooks/useHelp/useHelp.tsx
@@ -19,7 +19,7 @@ export const useHelp = () => {
   } = useTreeStore((state) => state);
 
   const showHelp = (contentId: string | undefined) => {
-    if (!contentId) return;
+    if (!contentId) throw new Error('contentId is required');
     storeShowHelp(contentId);
   };
 

--- a/src/store/DecisionTreeStore/decisionTreeStore.ts
+++ b/src/store/DecisionTreeStore/decisionTreeStore.ts
@@ -19,6 +19,7 @@ export interface DecisionTreeStore {
   hideNiblings: (nodeId: string) => void;
   addDecisionToPath: (source: string, target: string) => void;
   removeDecisionFromPath: (nodeId: string) => void;
+  buildPathToNode: (nodeId: string) => void;
 }
 
 /** The state of the decision tree, implemented as a shared slice that builds on concrete slices
@@ -79,5 +80,10 @@ export const createDecisionTreeStore: StateCreator<
       .getPath()
       .filter((decision) => !decisionIdsToRemove.includes(decision.nodeId));
     get().setPath(pathWithoutDescendants);
+  },
+  buildPathToNode: (nodeId: string) => {
+    const ancestorIds = get().getAncestorDecisions(nodeId);
+    const newDecisions = buildAncestorDecisions(get().tree, [...ancestorIds, nodeId]);
+    get().setPath(newDecisions);
   },
 });

--- a/src/store/DecisionTreeStore/decisionTreeStore.ts
+++ b/src/store/DecisionTreeStore/decisionTreeStore.ts
@@ -20,6 +20,7 @@ export interface DecisionTreeStore {
   addDecisionToPath: (source: string, target: string) => void;
   removeDecisionFromPath: (nodeId: string) => void;
   buildPathToNode: (nodeId: string) => void;
+  getParentId: (nodeId: string) => string | undefined;
 }
 
 /** The state of the decision tree, implemented as a shared slice that builds on concrete slices
@@ -85,5 +86,8 @@ export const createDecisionTreeStore: StateCreator<
     const ancestorIds = get().getAncestorDecisions(nodeId);
     const newDecisions = buildAncestorDecisions(get().tree, [...ancestorIds, nodeId]);
     get().setPath(newDecisions);
+  },
+  getParentId: (nodeId: string) => {
+    return get().getParentVertexId(nodeId);
   },
 });

--- a/src/store/DecisionTreeStore/decisionTreeStore.ts
+++ b/src/store/DecisionTreeStore/decisionTreeStore.ts
@@ -19,7 +19,6 @@ export interface DecisionTreeStore {
   hideNiblings: (nodeId: string) => void;
   addDecisionToPath: (source: string, target: string) => void;
   removeDecisionFromPath: (nodeId: string) => void;
-  buildPathToNode: (nodeId: string) => void;
   getParentId: (nodeId: string) => string | undefined;
 }
 
@@ -81,11 +80,6 @@ export const createDecisionTreeStore: StateCreator<
       .getPath()
       .filter((decision) => !decisionIdsToRemove.includes(decision.nodeId));
     get().setPath(pathWithoutDescendants);
-  },
-  buildPathToNode: (nodeId: string) => {
-    const ancestorIds = get().getAncestorDecisions(nodeId);
-    const newDecisions = buildAncestorDecisions(get().tree, [...ancestorIds, nodeId]);
-    get().setPath(newDecisions);
   },
   getParentId: (nodeId: string) => {
     return get().getParentVertexId(nodeId);

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -1,6 +1,11 @@
 import { Node } from 'reactflow';
 import { layoutTree } from 'store/TreeSlice/layout';
-import { getAncestorIds, setNodesHidden, setNodeVisible } from 'store/TreeSlice/treeSliceUtils';
+import {
+  getAncestorIds,
+  getParentId,
+  setNodesHidden,
+  setNodeVisible,
+} from 'store/TreeSlice/treeSliceUtils';
 import { StateCreator } from 'zustand';
 
 /** Data needed by all nodes in our tree*/
@@ -62,6 +67,8 @@ interface TreeSliceActions {
   removePathDecision: (nodeId: string) => void;
   /** get ancestor IDs */
   getAncestorDecisions: (nodeId: string) => string[];
+  /** get a node's parent ID */
+  getParentVertexId: (nodeId: string) => string | undefined;
 }
 
 export interface TreeSlice extends TreeSliceActions, TreeSliceState {}
@@ -140,5 +147,9 @@ export const createTreeSlice: StateCreator<
   getAncestorDecisions: (nodeId: string) => {
     const tree = get().tree;
     return getAncestorIds(tree, nodeId);
+  },
+  getParentVertexId: (nodeId: string) => {
+    const tree = get().tree;
+    return getParentId(tree, nodeId);
   },
 });

--- a/src/store/TreeSlice/treeSliceUtils.spec.ts
+++ b/src/store/TreeSlice/treeSliceUtils.spec.ts
@@ -3,10 +3,57 @@ import { DecisionTree } from 'store/DagNodeSlice/dagNodeSlice';
 import {
   buildAncestorDecisions,
   getAncestorIds,
+  getParentId,
   setNodesHidden,
   setNodeVisible,
 } from 'store/TreeSlice/treeSliceUtils';
 import { describe, expect, suite, test } from 'vitest';
+
+const treeFactory = (overwrites?: Partial<DecisionTree>): DecisionTree => {
+  const parent = 'parent';
+  const child = 'child';
+  const grandparent = 'grandparent';
+  const uncle = 'uncle';
+  return {
+    [grandparent]: {
+      id: grandparent,
+      hidden: false,
+      data: { label: grandparent, children: [parent, uncle] },
+      position: {
+        x: 0,
+        y: 0,
+      },
+    },
+    [parent]: {
+      id: parent,
+      hidden: false,
+      data: { label: parent, children: [child] },
+      position: {
+        x: 0,
+        y: 0,
+      },
+    },
+    [uncle]: {
+      id: uncle,
+      hidden: false,
+      data: { label: uncle, children: [] },
+      position: {
+        x: 0,
+        y: 0,
+      },
+    },
+    [child]: {
+      id: child,
+      hidden: false,
+      data: { label: child, children: [] },
+      position: {
+        x: 0,
+        y: 0,
+      },
+    },
+    ...overwrites,
+  };
+};
 
 suite('Tree Slice internals', () => {
   describe('Set Node Visible', () => {
@@ -34,100 +81,38 @@ suite('Tree Slice internals', () => {
     });
   });
   describe('Get Ancestor IDs', () => {
-    const parent = 'foo';
-    const child = 'bar';
-    const grandparent = 'baz';
-    const data: DecisionTree = {
-      [grandparent]: {
-        id: grandparent,
-        hidden: false,
-        data: { label: grandparent, children: [parent] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-      [parent]: {
-        id: parent,
-        hidden: false,
-        data: { label: parent, children: [child] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-      child: {
-        id: child,
-        hidden: false,
-        data: { label: child, children: [] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-    };
     test('Returns an array', () => {
-      expect(getAncestorIds(data, parent)).toBeInstanceOf(Array);
+      expect(getAncestorIds(treeFactory(), 'parent')).toBeInstanceOf(Array);
     });
     test('Returns an empty array if the node has no ancestors', () => {
-      expect(getAncestorIds(data, grandparent)).toEqual([]);
+      expect(getAncestorIds(treeFactory(), 'grandparent')).toEqual([]);
     });
     test('Returns the parent and grandparent node IDs', () => {
-      expect(getAncestorIds(data, child)).toEqual([parent, grandparent]);
+      expect(getAncestorIds(treeFactory(), 'child')).toEqual(['parent', 'grandparent']);
     });
   });
   describe('build ancestor decisions', () => {
-    const parent = 'foo';
-    const child = 'bar';
-    const grandparent = 'baz';
-    const uncle = 'uncle';
-    const data: DecisionTree = {
-      [grandparent]: {
-        id: grandparent,
-        hidden: false,
-        data: { label: grandparent, children: [parent, uncle] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-      [parent]: {
-        id: parent,
-        hidden: false,
-        data: { label: parent, children: [child] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-      [uncle]: {
-        id: uncle,
-        hidden: false,
-        data: { label: uncle, children: [] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-      child: {
-        id: child,
-        hidden: false,
-        data: { label: child, children: [] },
-        position: {
-          x: 0,
-          y: 0,
-        },
-      },
-    };
     test('Returns an array', () => {
-      expect(buildAncestorDecisions(data, [parent, grandparent])).toBeInstanceOf(Array);
+      expect(buildAncestorDecisions(treeFactory(), ['parent', 'grandparent'])).toBeInstanceOf(
+        Array
+      );
     });
     test('returns an array of objects with the decisions', () => {
-      const decisions = buildAncestorDecisions(data, [parent, grandparent]);
+      const decisions = buildAncestorDecisions(treeFactory(), ['parent', 'grandparent']);
       decisions.map((decision) => {
         expect(decision.nodeId).toBeDefined();
         expect(decision.selected).toBeDefined();
       });
+    });
+  });
+  describe('Get Parent ID', () => {
+    test('Returns the parent ID', () => {
+      const retrievedParentId = getParentId(treeFactory(), 'child');
+      expect(retrievedParentId).toBe('parent');
+    });
+    test('Returns undefined if root node', () => {
+      const retrievedParentId = getParentId(treeFactory(), 'grandparent');
+      expect(retrievedParentId).toBeUndefined();
     });
   });
 });

--- a/src/store/TreeSlice/treeSliceUtils.ts
+++ b/src/store/TreeSlice/treeSliceUtils.ts
@@ -37,3 +37,9 @@ export const buildAncestorDecisions = (tree: DecisionTree, ancestorIds: string[]
   });
   return decisions;
 };
+
+/** find the ID of the parent node */
+export const getParentId = (tree: DecisionTree, nodeId: string): string | undefined => {
+  const parent = Object.values(tree).find((node) => node.data.children?.includes(nodeId));
+  return parent?.id;
+};


### PR DESCRIPTION
## Description

This PR renders the tree based on the URL query parameter `path` if it is set upon loading the page. 


A departure from #124 we actually, do not update the URL when a user makes a decision. 

The reasons for this departure. 

 1. We don't want the user to have to click the back button 1 BILLION times after using TMG. This would not be a expected behavior to most users of the web since the page doesn't change from their perspective.
 2.  It means we would be storing the state of the path in multiple locations that would be unnecessary and costly to keep in sync.

## Issue ticket number and link

closes #100 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
