### PR TITLE
multi decision tree url state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { OffCanvas } from '@/components/OffCanvas/OffCanvas';
 import { Spinner } from '@/components/Spinner/Spinner';
 import { Tree } from '@/components/Tree/Tree';
 import { useDecisionTree, useFetchConfig, useHelp, useUrl } from '@/hooks';
+import { useEffect } from 'react';
 
 /**
  * App - responsible for rendering the decision tree
@@ -13,9 +14,15 @@ import { useDecisionTree, useFetchConfig, useHelp, useUrl } from '@/hooks';
 export default function App() {
   const title = import.meta.env.VITE_APP_TITLE ?? 'The Manifest Game';
   const { config, isLoading: configIsLoading, error: configError } = useFetchConfig(defaultTree);
-  const { pathParam } = useUrl();
+  const { pathParam, treeParam, setTreeParam } = useUrl();
   const { nodes, edges } = useDecisionTree(config, pathParam);
   const { helpIsOpen, hideHelp } = useHelp();
+
+  useEffect(() => {
+    if (!treeParam) {
+      setTreeParam('0');
+    }
+  }, [treeParam, setTreeParam]);
 
   return (
     <>

--- a/src/hooks/useUrl/useUrl.tsx
+++ b/src/hooks/useUrl/useUrl.tsx
@@ -5,6 +5,8 @@ import { useLocation, useSearchParams } from 'react-router-dom';
 export interface UsesPathReturn {
   pathParam: string;
   setPathParam: (pathId: string) => void;
+  treeParam: string;
+  setTreeParam: (treeId: string) => void;
   pathname: string;
   copyTreeUrlToClipboard: () => void;
 }
@@ -15,6 +17,7 @@ export interface UsesPathReturn {
 export const useUrl = () => {
   const [urlQueryParams, setUrlQueryParams] = useSearchParams();
   const [pathParam, setPathParam] = useState<string | null | undefined>(urlQueryParams.get('path'));
+  const [treeParam, setTreeParam] = useState<string | null | undefined>(urlQueryParams.get('tree'));
   const { pathname } = useLocation();
   const { path } = useDecisions();
 
@@ -22,6 +25,12 @@ export const useUrl = () => {
     urlQueryParams.set('path', pathId);
     setUrlQueryParams(urlQueryParams);
     setPathParam(pathId);
+  };
+
+  const setUrlTreeId = (treeId: string) => {
+    urlQueryParams.set('tree', treeId);
+    setUrlQueryParams(urlQueryParams);
+    setTreeParam(treeId);
   };
 
   const copyUrl = () => {
@@ -35,6 +44,8 @@ export const useUrl = () => {
   return {
     pathParam,
     setPathParam: setUrlPathId,
+    treeParam,
+    setTreeParam: setUrlTreeId,
     pathname,
     copyTreeUrlToClipboard: copyUrl,
   } as UsesPathReturn;


### PR DESCRIPTION
## Description

adds a URL query parameter to our application used to decide wich decision tree is being used. 

I'v decided to go with a query parameter for the time being, since GitHub pages does not support SPA routing, this may need to be changed though. 

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
