### PR TITLE
replace magic values for orientation with named constants

### DIFF
--- a/src/components/Tree/ControlCenter/ControlCenter.spec.tsx
+++ b/src/components/Tree/ControlCenter/ControlCenter.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { ControlCenter } from '@/components/Tree/ControlCenter/index';
 import { TreeDirection } from '@/store';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
 import { renderWithProviders } from '@/test-utils';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -19,7 +20,7 @@ const TestComponent = ({ ...props }: TestComponentProps) => {
   const mapVisible = props?.mapVisible ?? true;
   const onClick = props?.setMapVisible ?? dummyFunc;
   const setDirection = props?.setDirection ?? dummyFunc;
-  const direction = props?.direction ?? 'TB';
+  const direction = props?.direction ?? ORIENTATION.topToBottom;
 
   return (
     <ReactFlowProvider>
@@ -64,7 +65,7 @@ describe('ControlCenter', () => {
     const user = userEvent.setup();
     const setDirection = vi.fn();
     const { rerender } = renderWithProviders(
-      <TestComponent setDirection={setDirection} direction={'LR'} />
+      <TestComponent setDirection={setDirection} direction={ORIENTATION.leftToRight} />
     );
     await user.click(screen.getByRole('button', { name: /layout/i }));
     expect(setDirection).toHaveBeenCalled();

--- a/src/components/Tree/ControlCenter/ControlCenter.tsx
+++ b/src/components/Tree/ControlCenter/ControlCenter.tsx
@@ -1,8 +1,9 @@
 import { LayoutBtn } from '@/components/Tree/ControlCenter/Controls/LayoutBtn/LayoutBtn';
 import { MiniMapBtn } from '@/components/Tree/ControlCenter/Controls/MiniMapBtn/MiniMapBtn';
 import { ShareBtn } from '@/components/Tree/ControlCenter/Controls/ShareBtn/ShareBtn';
-import { Controls } from 'reactflow';
 import { TreeDirection } from '@/store';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
+import { Controls } from 'reactflow';
 
 export interface ControlCenterProps {
   mapVisible: boolean;
@@ -21,10 +22,12 @@ export const ControlCenter = ({
   const toggleMap = () => {
     setMapVisible(!mapVisible);
   };
-  const isHorizontal = direction === 'LR';
+  const isHorizontal = direction === ORIENTATION.leftToRight;
 
   const toggleDirection = () => {
-    setDirection(direction === 'TB' ? 'LR' : 'TB');
+    setDirection(
+      direction === ORIENTATION.topToBottom ? ORIENTATION.leftToRight : ORIENTATION.topToBottom
+    );
   };
 
   return (

--- a/src/components/Tree/Nodes/BaseNode/BaseNode.spec.tsx
+++ b/src/components/Tree/Nodes/BaseNode/BaseNode.spec.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom';
-import { act, cleanup, render, screen } from '@testing-library/react';
 import { BaseNode } from '@/components/Tree/Nodes/BaseNode/BaseNode';
-import { ReactFlowProvider } from 'reactflow';
 import { useTreeStore } from '@/store';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { ReactFlowProvider } from 'reactflow';
 import { afterEach, describe, expect, test } from 'vitest';
 
 const TestComponent = () => {
@@ -31,12 +32,12 @@ describe('BaseNode', () => {
     expect(screen.getByTestId('node-1')).toBeInTheDocument();
   });
   test('handles changes in tree layout', () => {
-    useTreeStore.setState({ direction: 'LR' });
+    useTreeStore.setState({ direction: ORIENTATION.leftToRight });
     const { rerender } = render(<TestComponent />);
     expect(screen.getByTestId('left-handle')).toBeInTheDocument();
     expect(screen.getByTestId('right-handle')).toBeInTheDocument();
     act(() => {
-      useTreeStore.setState({ direction: 'TB' });
+      useTreeStore.setState({ direction: ORIENTATION.topToBottom });
     });
     rerender(<TestComponent />);
     expect(screen.getByTestId('top-handle')).toBeInTheDocument();

--- a/src/hooks/useTreeDirection/useTreeDirection.spec.tsx
+++ b/src/hooks/useTreeDirection/useTreeDirection.spec.tsx
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom';
 import { useTreeDirection } from '@/hooks/useTreeDirection/useTreeDirection';
+import { TreeDirection, useTreeStore } from '@/store';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useTreeStore, TreeDirection } from '@/store';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 afterEach(() => {
@@ -11,7 +12,7 @@ afterEach(() => {
 });
 beforeEach(() => {
   useTreeStore.setState({
-    direction: 'TB',
+    direction: ORIENTATION.topToBottom,
     tree: {
       '1': {
         id: '1',
@@ -37,26 +38,26 @@ const TestComponent = ({
     <>
       <p>{direction}</p>
       <p>{isHorizontal ? 'horizontal' : 'vertical'}</p>
-      <button onClick={() => setDirection(newDir || 'LR')}>set direction</button>
+      <button onClick={() => setDirection(newDir || ORIENTATION.leftToRight)}>set direction</button>
     </>
   );
 };
 
 describe('useTreeDirection', () => {
   test('returns the current direction', () => {
-    render(<TestComponent initialDir={'TB'} />);
-    expect(screen.getByText('TB')).toBeInTheDocument();
+    render(<TestComponent initialDir={ORIENTATION.topToBottom} />);
+    expect(screen.getByText(ORIENTATION.topToBottom)).toBeInTheDocument();
   });
   test('sets the tree direction', async () => {
     const user = userEvent.setup();
-    render(<TestComponent initialDir={'TB'} newDir={'LR'} />);
+    render(<TestComponent initialDir={ORIENTATION.topToBottom} newDir={ORIENTATION.leftToRight} />);
     const button = screen.getByText('set direction');
     await user.click(button);
-    expect(screen.queryByText('LR')).toBeInTheDocument();
+    expect(screen.queryByText(ORIENTATION.leftToRight)).toBeInTheDocument();
   });
   test('exposes a boolean that indicates whether the tree layout is horizontal', async () => {
     const user = userEvent.setup();
-    render(<TestComponent initialDir={'LR'} newDir={'TB'} />);
+    render(<TestComponent initialDir={ORIENTATION.leftToRight} newDir={ORIENTATION.topToBottom} />);
     expect(screen.queryByText('horizontal')).toBeInTheDocument();
     await user.click(screen.getByText('set direction'));
     expect(screen.queryByText('vertical')).toBeInTheDocument();

--- a/src/hooks/useTreeDirection/useTreeDirection.tsx
+++ b/src/hooks/useTreeDirection/useTreeDirection.tsx
@@ -1,5 +1,6 @@
+import { TreeDirection, useTreeStore } from '@/store';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
 import { useEffect } from 'react';
-import { useTreeStore, TreeDirection } from '@/store';
 
 /**
  * Returns the current direction of the node layout and a setter. The direction can be set to
@@ -17,7 +18,7 @@ export const useTreeDirection = (initialDir?: TreeDirection) => {
     if (initialDir) setStoreDirection(initialDir);
   }, [initialDir, setStoreDirection]);
 
-  const isHorizontal: boolean = direction === 'LR';
+  const isHorizontal: boolean = direction === ORIENTATION.leftToRight;
 
   return [direction, setDirection, isHorizontal] as const;
 };

--- a/src/store/TreeSlice/layout.spec.ts
+++ b/src/store/TreeSlice/layout.spec.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { PositionUnawareDecisionTree } from '@/store/DagNodeSlice/dagNodeSlice';
 import { layoutTree } from '@/store/TreeSlice/layout';
+import { ORIENTATION } from '@/store/TreeSlice/treeSlice';
 import { describe, expect, test } from 'vitest';
 
 describe('DAG layout', () => {
@@ -40,7 +41,7 @@ describe('DAG layout', () => {
         },
       },
     };
-    const direction = 'LR';
+    const direction = ORIENTATION.leftToRight;
     const horizontalTree = layoutTree(positionUnawareTree, direction);
     const verticalTree = layoutTree(positionUnawareTree);
     expect(horizontalTree[parentId].position.x).toBeLessThanOrEqual(

--- a/src/store/TreeSlice/layout.ts
+++ b/src/store/TreeSlice/layout.ts
@@ -1,8 +1,8 @@
-import dagre from '@dagrejs/dagre';
-import { Edge } from 'reactflow';
 import { createDagEdge } from '@/store/DagEdgeSlice/dagEdgeUtils';
 import { DecisionTree, PositionUnawareDecisionTree } from '@/store/DagNodeSlice/dagNodeSlice';
-import { TreeDirection } from '@/store/TreeSlice/treeSlice';
+import { ORIENTATION, TreeDirection } from '@/store/TreeSlice/treeSlice';
+import dagre from '@dagrejs/dagre';
+import { Edge } from 'reactflow';
 
 const dagreGraph = new dagre.graphlib.Graph<{
   x: number;
@@ -26,7 +26,7 @@ const boolNodeHeight = defaultNodeHeight + 50;
  */
 export const layoutTree = (
   tree?: PositionUnawareDecisionTree,
-  direction: TreeDirection = 'LR'
+  direction: TreeDirection = ORIENTATION.leftToRight
 ): DecisionTree => {
   if (!tree) return {};
   dagreGraph.setGraph({ rankdir: direction });
@@ -60,8 +60,12 @@ export const layoutTree = (
     decisionTree[node.id] = {
       ...node,
       position: {
-        x: position.x - (defaultNodeWidth + direction === 'LR' ? defaultNodeWidth : 0) / 2,
-        y: position.y - (defaultNodeHeight + direction === 'LR' ? -boolNodeHeight : 0) / 2,
+        x:
+          position.x -
+          (defaultNodeWidth + direction === ORIENTATION.leftToRight ? defaultNodeWidth : 0) / 2,
+        y:
+          position.y -
+          (defaultNodeHeight + direction === ORIENTATION.leftToRight ? -boolNodeHeight : 0) / 2,
         rank: position.rank,
       },
     };

--- a/src/store/TreeSlice/treeSlice.spec.ts
+++ b/src/store/TreeSlice/treeSlice.spec.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
-import { createTreeSlice, Decision, DecisionPath, TreeSlice } from '@/store/TreeSlice/treeSlice';
+import {
+  createTreeSlice,
+  Decision,
+  DecisionPath,
+  ORIENTATION,
+  TreeSlice,
+} from '@/store/TreeSlice/treeSlice';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, suite, test } from 'vitest';
 import { create } from 'zustand';
@@ -14,7 +20,7 @@ suite('Tree Slice', () => {
     test('Default direction is left-to-right', () => {
       // @ts-expect-error -- relaxing types for testing
       const { result } = renderHook(() => create(createTreeSlice));
-      expect(result.current.getState().direction).toEqual('LR');
+      expect(result.current.getState().direction).toEqual(ORIENTATION.leftToRight);
     });
   });
   describe('Decision path', () => {

--- a/src/store/TreeSlice/treeSlice.ts
+++ b/src/store/TreeSlice/treeSlice.ts
@@ -1,4 +1,3 @@
-import { Node } from 'reactflow';
 import { layoutTree } from '@/store/TreeSlice/layout';
 import {
   getAncestorIds,
@@ -6,6 +5,7 @@ import {
   setNodesHidden,
   setNodeVisible,
 } from '@/store/TreeSlice/treeSliceUtils';
+import { Node } from 'reactflow';
 import { StateCreator } from 'zustand';
 
 /** Data needed by all nodes in our tree*/
@@ -35,7 +35,12 @@ export type DecisionTree = Record<string, Vertex>;
 
 export type PositionUnawareDecisionTree = Record<string, Omit<Vertex, 'position'>>;
 
-export type TreeDirection = 'TB' | 'LR';
+export const ORIENTATION = {
+  leftToRight: 'LR',
+  topToBottom: 'TB',
+};
+
+export type TreeDirection = (typeof ORIENTATION)[keyof typeof ORIENTATION];
 
 export interface Decision {
   nodeId: string;
@@ -79,7 +84,7 @@ export const createTreeSlice: StateCreator<
   [],
   TreeSlice
 > = (set, get) => ({
-  direction: 'LR',
+  direction: ORIENTATION.leftToRight,
   tree: {},
   path: [],
   setTreeDirection: (direction: TreeDirection) => {


### PR DESCRIPTION
## Description

small change:
- Avoid using strings like `'LR'` and `'TB'` to represent the orientation throughout the codebase and instead use a named constant consistently. 

## Issue ticket number and link

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
